### PR TITLE
Refactor layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@3dbionotes/protvista-pdb",
-  "version": "2.0.1-beta.9",
+  "version": "2.0.1-beta.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@3dbionotes/protvista-pdb",
-      "version": "2.0.1-beta.9",
+      "version": "2.0.1-beta.11",
       "license": "Apache 2.0",
       "dependencies": {
         "lodash-es": "^4.17.11",
@@ -21,7 +21,6 @@
         "@babel/core": "^7.3.3",
         "@babel/plugin-transform-runtime": "^7.6.2",
         "@babel/preset-env": "^7.3.1",
-        "@babel/preset-react": "^7.22.5",
         "@babel/runtime": "^7.3.1",
         "babel-loader": "^8.0.5",
         "camelcase": "^5.0.0",
@@ -334,15 +333,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-validator-option": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.5.tgz",
-      "integrity": "sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-wrap-function": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.10.4.tgz",
@@ -568,21 +558,6 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.22.5.tgz",
-      "integrity": "sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
@@ -878,71 +853,6 @@
         "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
-    "node_modules/@babel/plugin-transform-react-display-name": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.22.5.tgz",
-      "integrity": "sha512-PVk3WPYudRF5z4GKMEYUrLjPl38fJSKNaEOkFuoprioowGuWN6w2RKznuFNSlJx7pzzXXStPUnNSOEO0jL5EVw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-jsx": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.22.5.tgz",
-      "integrity": "sha512-rog5gZaVbUip5iWDMTYbVM15XQq+RkUKhET/IHR6oizR+JEoN6CAfTTuHcK4vwUyzca30qqHqEpzBOnaRMWYMA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.22.5",
-        "@babel/helper-module-imports": "^7.22.5",
-        "@babel/helper-plugin-utils": "^7.22.5",
-        "@babel/plugin-syntax-jsx": "^7.22.5",
-        "@babel/types": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-jsx-development": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.22.5.tgz",
-      "integrity": "sha512-bDhuzwWMuInwCYeDeMzyi7TaBgRQei6DqxhbyniL7/VG4RSS7HtSL2QbY4eESy1KJqlWt8g3xeEBGPuo+XqC8A==",
-      "dev": true,
-      "dependencies": {
-        "@babel/plugin-transform-react-jsx": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-pure-annotations": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.22.5.tgz",
-      "integrity": "sha512-gP4k85wx09q+brArVinTXhWiyzLl9UpmGva0+mWyKxk6JZequ05x3eUcIUE+FyttPKJFRRVtAvQaJ6YF9h1ZpA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.22.5",
-        "@babel/helper-plugin-utils": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-transform-regenerator": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.10.4.tgz",
@@ -1127,26 +1037,6 @@
         "@babel/plugin-transform-dotall-regex": "^7.4.4",
         "@babel/types": "^7.4.4",
         "esutils": "^2.0.2"
-      }
-    },
-    "node_modules/@babel/preset-react": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.22.5.tgz",
-      "integrity": "sha512-M+Is3WikOpEJHgR385HbuCITPTaPRaNkibTEa9oiofmJvIsrceb4yp9RL9Kb+TE8LznmeyZqpP+Lopwcx59xPQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.22.5",
-        "@babel/helper-validator-option": "^7.22.5",
-        "@babel/plugin-transform-react-display-name": "^7.22.5",
-        "@babel/plugin-transform-react-jsx": "^7.22.5",
-        "@babel/plugin-transform-react-jsx-development": "^7.22.5",
-        "@babel/plugin-transform-react-pure-annotations": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -6667,12 +6557,6 @@
       "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
       "dev": true
     },
-    "@babel/helper-validator-option": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.5.tgz",
-      "integrity": "sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==",
-      "dev": true
-    },
     "@babel/helper-wrap-function": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.10.4.tgz",
@@ -6889,15 +6773,6 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
-      }
-    },
-    "@babel/plugin-syntax-jsx": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.22.5.tgz",
-      "integrity": "sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.22.5"
       }
     },
     "@babel/plugin-syntax-logical-assignment-operators": {
@@ -7193,47 +7068,6 @@
         "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
-    "@babel/plugin-transform-react-display-name": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.22.5.tgz",
-      "integrity": "sha512-PVk3WPYudRF5z4GKMEYUrLjPl38fJSKNaEOkFuoprioowGuWN6w2RKznuFNSlJx7pzzXXStPUnNSOEO0jL5EVw==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.22.5"
-      }
-    },
-    "@babel/plugin-transform-react-jsx": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.22.5.tgz",
-      "integrity": "sha512-rog5gZaVbUip5iWDMTYbVM15XQq+RkUKhET/IHR6oizR+JEoN6CAfTTuHcK4vwUyzca30qqHqEpzBOnaRMWYMA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-annotate-as-pure": "^7.22.5",
-        "@babel/helper-module-imports": "^7.22.5",
-        "@babel/helper-plugin-utils": "^7.22.5",
-        "@babel/plugin-syntax-jsx": "^7.22.5",
-        "@babel/types": "^7.22.5"
-      }
-    },
-    "@babel/plugin-transform-react-jsx-development": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.22.5.tgz",
-      "integrity": "sha512-bDhuzwWMuInwCYeDeMzyi7TaBgRQei6DqxhbyniL7/VG4RSS7HtSL2QbY4eESy1KJqlWt8g3xeEBGPuo+XqC8A==",
-      "dev": true,
-      "requires": {
-        "@babel/plugin-transform-react-jsx": "^7.22.5"
-      }
-    },
-    "@babel/plugin-transform-react-pure-annotations": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.22.5.tgz",
-      "integrity": "sha512-gP4k85wx09q+brArVinTXhWiyzLl9UpmGva0+mWyKxk6JZequ05x3eUcIUE+FyttPKJFRRVtAvQaJ6YF9h1ZpA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-annotate-as-pure": "^7.22.5",
-        "@babel/helper-plugin-utils": "^7.22.5"
-      }
-    },
     "@babel/plugin-transform-regenerator": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.10.4.tgz",
@@ -7418,20 +7252,6 @@
         "@babel/plugin-transform-dotall-regex": "^7.4.4",
         "@babel/types": "^7.4.4",
         "esutils": "^2.0.2"
-      }
-    },
-    "@babel/preset-react": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.22.5.tgz",
-      "integrity": "sha512-M+Is3WikOpEJHgR385HbuCITPTaPRaNkibTEa9oiofmJvIsrceb4yp9RL9Kb+TE8LznmeyZqpP+Lopwcx59xPQ==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.22.5",
-        "@babel/helper-validator-option": "^7.22.5",
-        "@babel/plugin-transform-react-display-name": "^7.22.5",
-        "@babel/plugin-transform-react-jsx": "^7.22.5",
-        "@babel/plugin-transform-react-jsx-development": "^7.22.5",
-        "@babel/plugin-transform-react-pure-annotations": "^7.22.5"
       }
     },
     "@babel/runtime": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@3dbionotes/protvista-pdb",
-  "version": "2.0.1-beta.10",
+  "version": "2.0.1-beta.11",
   "description": "PDB ProtVista Viewer",
   "files": [
     "dist",

--- a/src/custom-pv-components/pdb-track.js
+++ b/src/custom-pv-components/pdb-track.js
@@ -45,7 +45,7 @@ class ProtvistaPdbTrack extends ProtvistaTrack {
 
     // this.trackHighlighter.appendHighlightTo(this.svg);
 
-    this.seq_g = this.svg.append("g").attr("class", "sequence-features").attr("transform", "translate(0,-5)");
+    this.seq_g = this.svg.append("g").attr("class", "sequence-features").attr("transform", "translate(0,-9)");
 
     this._createFeatures();
     this.refresh();

--- a/src/custom-pv-components/pdb-track.js
+++ b/src/custom-pv-components/pdb-track.js
@@ -45,7 +45,7 @@ class ProtvistaPdbTrack extends ProtvistaTrack {
 
     // this.trackHighlighter.appendHighlightTo(this.svg);
 
-    this.seq_g = this.svg.append("g").attr("class", "sequence-features").attr("transform", "translate(0,-9)");
+    this.seq_g = this.svg.append("g").attr("class", "sequence-features").attr("transform", "translate(0,-8)");
 
     this._createFeatures();
     this.refresh();

--- a/src/helpers/layout.js
+++ b/src/helpers/layout.js
@@ -5,7 +5,7 @@ class LayoutHelper {
     constructor(ctx) {
         this.ctx = ctx;
         this.handlers = [];
-        this.ctx.addEventListener('mouseleave',()=>{this.hideMoreOptions();});
+        this.ctx.addEventListener('mouseleave', () => { this.hideMoreOptions(); });
     }
 
     postProcessLayout() {
@@ -392,35 +392,30 @@ class LayoutHelper {
         
     }
 
-    zoomTrack(data, currentZoomTrack){
+    zoomTrack(data, currentZoomTrack) {
+        const changeIcon = (el, zoom) => {
+            if (zoom) el.classList.add('active');
+            else el.classList.remove('active');
+            const icon = el.children[0];
+            const text = el.children[1];
+            if (icon && text) {
+                icon.classList.add(zoom ? "icon-search-minus" : "icon-search-plus");
+                icon.classList.remove(zoom ? "icon-search-plus" : "icon-search-minus");
+                text.innerText = zoom ? "Zoom out" : "Zoom in";
+            }
+        }
 
-        if(this.ctx.zoomedTrack != ''){
-            let prevZoomIconEle = this.ctx.querySelector('.pvZoomIcon_'+this.ctx.zoomedTrack);
-            prevZoomIconEle.classList.remove('active');
-            const icon=prevZoomIconEle.children[0];
-            const text=prevZoomIconEle.children[1];
-            icon.classList.remove("icon-search-minus");
-            icon.classList.add("icon-search-plus");
-            text.innerText="Zoom in";
+        if (this.ctx.zoomedTrack != '')
+            changeIcon(this.ctx.querySelector('.pvZoomIcon_' + this.ctx.zoomedTrack), false);
+
+        if (this.ctx.zoomedTrack != currentZoomTrack) {
+            changeIcon(this.ctx.querySelector('.pvZoomIcon_' + currentZoomTrack), true);
+            this.ctx.zoomedTrack = currentZoomTrack;
+            this.resetZoom(data);
+        } else {
+            this.ctx.zoomedTrack = '';
+            this.resetZoom({ start: 1, end: null });
         }
-        
-        if(this.ctx.zoomedTrack != currentZoomTrack){
-          
-          let zoomIconEle = this.ctx.querySelector('.pvZoomIcon_'+currentZoomTrack);
-          zoomIconEle.classList.add('active');
-          const icon=zoomIconEle.children[0];
-          const text=zoomIconEle.children[1];
-          icon.classList.add("icon-search-minus");
-          icon.classList.remove("icon-search-plus");
-          text.innerText="Zoom out";
-          this.ctx.zoomedTrack = currentZoomTrack;
-          this.resetZoom(data);
-        }else{
-          
-          this.ctx.zoomedTrack = '';
-          this.resetZoom({start:1, end: null});
-        }
-          
     }
 
     resetView(){
@@ -508,78 +503,74 @@ class LayoutHelper {
         
     }
 
-    openRangeMenu(){
+    openTooltip(className, top, callback) {
+        const menu = this.ctx.querySelector(className);
+        if (menu.style.display == 'none') {
+            const actionSource = menu.previousElementSibling.getBoundingClientRect();
+            menu.style.left = (actionSource.x + actionSource.width + 16) + 'px';
+            menu.style.top = (actionSource.y + top) + 'px';
+            menu.style.display = 'block';
+            if (callback) callback(menu, this.ctx);
+        } else {
+            menu.style.display = 'none';
+        }
+    }
 
+    openRangeMenu() {
         //Close other open menus
         this.ctx.querySelector('.settingsMenu').style.display = 'none';
         this.hideMoreOptions();
         this.hideInfoTooltips();
-        
-        let menuBox = this.ctx.querySelector(`.rangeMenu`);
-        const menuAction = menuBox.previousElementSibling.getBoundingClientRect();
-        if(menuBox.style.display == 'none'){
-            menuBox.style.left = (menuAction.x + menuAction.width + 16) +'px';
-            menuBox.style.top = (menuAction.y + 16) +'px';
-            menuBox.style.display = 'block';
-            let startEle = this.ctx.querySelector('.pvRangeMenuStart');
-            let endEle = this.ctx.querySelector('.pvRangeMenuEnd');
-            
-            if(startEle.value == 0 || endEle.value == 0){
-                let currentStartVal = 1;
-                let currentEndVal = this.ctx.viewerData.length;
 
-                let navEle = this.ctx.querySelectorAll('.pvTrack')[0];
-                if (navEle){
+        function rangeMenu(_menu, ctx) {
+            let startEle = ctx.querySelector('.pvRangeMenuStart');
+            let endEle = ctx.querySelector('.pvRangeMenuEnd');
+
+            if (startEle.value == 0 || endEle.value == 0) {
+                let currentStartVal = 1;
+                let currentEndVal = ctx.viewerData.length;
+
+                let navEle = ctx.querySelectorAll('.pvTrack')[0];
+                if (navEle) {
                     currentStartVal = navEle.getAttribute('displaystart');
                     currentEndVal = navEle.getAttribute('displayend');
                 }
-                
+
                 startEle.value = Math.round(currentStartVal);
                 endEle.value = Math.round(currentEndVal);
             }
-
-            menuBox.style.display = 'block';
-        }else{
-            menuBox.style.display = 'none';
         }
+
+        this.openTooltip(".rangeMenu", 16, rangeMenu);
     }
 
-    openMoreOptions(trackIndex, subtrackIndex){
+    openMoreOptions(trackIndex, subtrackIndex) {
+        //Close other open menus
+        this.ctx.querySelector('.settingsMenu').style.display = 'none';
+        this.ctx.querySelector('.rangeMenu').style.display = 'none';
+        this.hideInfoTooltips();
+        this.hideMoreOptions();
+        this.openTooltip(`.moreOptionsMenu_${trackIndex}_${subtrackIndex}`, -16);
+    }
+
+    showInfoTooltip(trackIndex, subtrackIndex) {
         //Close other open menus
         this.ctx.querySelector('.settingsMenu').style.display = 'none';
         this.ctx.querySelector('.rangeMenu').style.display = 'none';
         this.hideInfoTooltips();
 
-        const menuBox = this.ctx.querySelector(`.moreOptionsMenu_${trackIndex}_${subtrackIndex}`);
-        if(menuBox.style.display == 'none') {
-            this.hideMoreOptions();
-            const moreOptions = menuBox.previousElementSibling.getBoundingClientRect();
-            menuBox.style.left = (moreOptions.x + moreOptions.width + 16) +'px';
-            menuBox.style.top = (moreOptions.y + -16) +'px';
-            menuBox.style.display = 'block';
-        } else {
-            menuBox.style.display = 'none';
-        }
-    }
-
-    showInfoTooltip(trackIndex, subtrackIndex){
-        //Close other open menus
-        this.ctx.querySelector('.settingsMenu').style.display = 'none';
-        this.ctx.querySelector('.rangeMenu').style.display = 'none';
-        this.hideInfoTooltips();
-        
         const tooltipBox = this.ctx.querySelector(`.infoTooltip_${trackIndex}_${subtrackIndex}`);
         const actionButton = this.ctx.querySelector(`.infoAction_${trackIndex}_${subtrackIndex}`).getBoundingClientRect();
-        tooltipBox.style.left = (actionButton.x + 24) +'px';
-        tooltipBox.style.top = (actionButton.y + -32) +'px';
+        tooltipBox.style.left = (actionButton.x + 24) + 'px';
+        tooltipBox.style.top = (actionButton.y + -32) + 'px';
         tooltipBox.style.display = 'block';
         this.hideMoreOptions();
     }
-    
-    hideMoreOptions(){
+
+    hideMoreOptions() {
         //Hide all more options menu
-        if(this.ctx)
-            [...this.ctx.querySelectorAll('.moreOptionsMenu')].forEach(m=>m.style.display = 'none');
+        if (this.ctx)
+            [...this.ctx.querySelectorAll('.moreOptionsMenu')].forEach(m => m.style.display = 'none');
     }
 
     hideInfoTooltips(){
@@ -595,25 +586,13 @@ class LayoutHelper {
         this.hideMoreOptions();
         this.hideInfoTooltips();
 
-        let menuBox = this.ctx.querySelector(`.settingsMenu`);
-        const menuAction = menuBox.previousElementSibling.getBoundingClientRect();
-        if(menuBox.style.display == 'none'){
-            menuBox.style.left = (menuAction.x + menuAction.width + 16) +'px';
-            menuBox.style.top = (menuAction.y + 16) +'px';
-            menuBox.style.display = 'block';
-            
-            menuBox.querySelectorAll('.pvSectionChkBox').forEach((chkBox, chkBoxIndex) => {
-                if(this.ctx.hiddenSections.indexOf(chkBoxIndex) > -1){
-                    chkBox.checked = true;
-                }else{
-                    chkBox.checked = false;
-                }
+        function settingsMenu(menu, ctx) {
+            menu.querySelectorAll('.pvSectionChkBox').forEach((chkBox, chkBoxIndex) => {
+                chkBox.checked = ctx.hiddenSections.indexOf(chkBoxIndex) > -1;
             });
-
-            menuBox.style.display = 'block';
-        }else{
-            menuBox.style.display = 'none';
         }
+
+        this.openTooltip(".settingsMenu", 16, settingsMenu);
     }
 
     pvRangeMenuSubmit(){

--- a/src/helpers/layout.js
+++ b/src/helpers/layout.js
@@ -5,6 +5,7 @@ class LayoutHelper {
     constructor(ctx) {
         this.ctx = ctx;
         this.handlers = [];
+        this.ctx.addEventListener('mouseleave',()=>{this.hideMoreOptions();});
     }
 
     postProcessLayout() {
@@ -69,7 +70,7 @@ class LayoutHelper {
 
     addDynamicTrackSection(resultData, rowClass, aggregatedTrackClass, trackClass, sectionOptions, borderBottom) {
         if(resultData && Object.keys(resultData).length > 0){
-            this.ctx.querySelector(rowClass).style.display = 'table';
+            this.ctx.querySelector(rowClass).style.display = 'flex';
             let trackSectionEle = this.ctx.querySelectorAll(aggregatedTrackClass)[0];
             if(trackSectionEle){ 
                 trackSectionEle.style.paddingRight = this.ctx.scrollbarWidth+'px';
@@ -127,7 +128,7 @@ class LayoutHelper {
 
     hideSubtracks(trackIndex){
         this.ctx.querySelectorAll('.pvSubtracks_'+trackIndex)[0].style.display = 'none';
-        this.ctx.querySelectorAll('.pvTracks_'+trackIndex)[0].style.display = 'table';
+        this.ctx.querySelectorAll('.pvTracks_'+trackIndex)[0].style.display = 'flex';
     }
 
     addHideOptions(optionClass, tIndex, label){
@@ -136,7 +137,7 @@ class LayoutHelper {
             <td style="width:10%;vertical-align:top;"><input type="checkbox" class="pvSectionChkBox" name="cb_${tIndex}" style="margin:0" /></td>
             <td style="padding-bottom:5px;">${label}</td>
         </tr>`;
-        optionEle.style.display = "table-row";
+        optionEle.style.display = "flex";
     }
 
     handleExtEvents(e){
@@ -248,7 +249,7 @@ class LayoutHelper {
     resetSection(trackIndex){
         this.ctx.querySelector(`.pvResetSection_${trackIndex}`).style.display = 'none';
         this.ctx.hiddenSubtracks[trackIndex].forEach((subtrackIndex) => {
-            this.ctx.querySelector(`.pvSubtrackRow_${trackIndex}_${subtrackIndex}`).style.display = 'table';
+            this.ctx.querySelector(`.pvSubtrackRow_${trackIndex}_${subtrackIndex}`).style.display = 'flex';
         });
         delete this.ctx.hiddenSubtracks[trackIndex];
     }
@@ -280,7 +281,7 @@ class LayoutHelper {
         let totalTracks = this.ctx.viewerData.tracks.length;
         if(trackIndex < totalTracks){
             let pvTracksEle = this.ctx.querySelector(`.pvTracks_${trackIndex}`);
-            pvTracksEle.style.display = 'table';
+            pvTracksEle.style.display = 'flex';
 
             if(pvTracksEle.classList.contains('expanded')){
                 let pvSbTrkEle = this.ctx.querySelector(`.pvSubtracks_${trackIndex}`);
@@ -293,7 +294,7 @@ class LayoutHelper {
 
             if(trackIndex == totalTracks){
                 let consHistoSectionEle = this.ctx.querySelector('.pvConsHistoRow');
-                if(consHistoSectionEle) consHistoSectionEle.style.display = 'table';
+                if(consHistoSectionEle) consHistoSectionEle.style.display = 'flex';
 
                 if(consHistoSectionEle.classList.contains('expanded')){
                     let pvConservationPlotSectionEle = this.ctx.querySelector('.pvConservationPlotRow');
@@ -301,7 +302,7 @@ class LayoutHelper {
                 }
             }else{
                 let variantGraphSectionEle = this.ctx.querySelector('.pvVariantGraphRow');
-                if(variantGraphSectionEle) variantGraphSectionEle.style.display = 'table';
+                if(variantGraphSectionEle) variantGraphSectionEle.style.display = 'flex';
                 if(variantGraphSectionEle.classList.contains('expanded')){
                     let pvVariantPlotSectionEle = this.ctx.querySelector('.pvVariantPlotRow');
                     if(pvVariantPlotSectionEle) pvVariantPlotSectionEle.style.display = 'block';
@@ -396,13 +397,22 @@ class LayoutHelper {
         if(this.ctx.zoomedTrack != ''){
             let prevZoomIconEle = this.ctx.querySelector('.pvZoomIcon_'+this.ctx.zoomedTrack);
             prevZoomIconEle.classList.remove('active');
+            const icon=prevZoomIconEle.children[0];
+            const text=prevZoomIconEle.children[1];
+            icon.classList.remove("icon-search-minus");
+            icon.classList.add("icon-search-plus");
+            text.innerText="Zoom in";
         }
         
         if(this.ctx.zoomedTrack != currentZoomTrack){
           
           let zoomIconEle = this.ctx.querySelector('.pvZoomIcon_'+currentZoomTrack);
           zoomIconEle.classList.add('active');
-
+          const icon=zoomIconEle.children[0];
+          const text=zoomIconEle.children[1];
+          icon.classList.add("icon-search-minus");
+          icon.classList.remove("icon-search-plus");
+          text.innerText="Zoom out";
           this.ctx.zoomedTrack = currentZoomTrack;
           this.resetZoom(data);
         }else{
@@ -418,6 +428,8 @@ class LayoutHelper {
         //Close open menus
         this.ctx.querySelector('.settingsMenu').style.display = 'none';
         this.ctx.querySelector('.rangeMenu').style.display = 'none';
+        this.hideMoreOptions();
+        this.hideInfoTooltips();
 
         //Reset zoom
         if(this.ctx.zoomedTrack != ''){
@@ -435,7 +447,7 @@ class LayoutHelper {
             if(expTrackEle) expTrackEle.style.display = 'block';
         });
         let firstTrackSection = this.ctx.querySelector(`.pvTracks_0`);
-        firstTrackSection.style.display = 'table';
+        firstTrackSection.style.display = 'flex';
         // if(!firstTrackSection.classList.contains('expanded')) firstTrackSection.classList.add('expanded');
         // firstTrackSection.querySelector(`.pvTrack`).style.display = 'none';
         this.ctx.querySelectorAll(`.protvistaRowGroup`).forEach((trackSubSection, subSectionIndex) => {
@@ -458,7 +470,7 @@ class LayoutHelper {
 
                 if(trackIndex > 0 && trackIndex < totalTracks){
                     let trackSection = this.ctx.querySelector(`.pvTracks_${trackIndex}`);
-                    trackSection.style.display = 'table';
+                    trackSection.style.display = 'flex';
                     if(trackSection.classList.contains('expanded')) trackSection.classList.remove('expanded');
                     trackSection.querySelector(`.pvTrack`).style.display = 'block';
                 }else if(trackIndex >= totalTracks){
@@ -466,7 +478,7 @@ class LayoutHelper {
                     if(trackIndex == totalTracks){
 
                         let consHistoSectionEle = this.ctx.querySelector('.pvConsHistoRow');
-                        if(consHistoSectionEle) consHistoSectionEle.style.display = 'table';
+                        if(consHistoSectionEle) consHistoSectionEle.style.display = 'flex';
         
                         if(consHistoSectionEle.classList.contains('expanded')) consHistoSectionEle.classList.remove('expanded');
                         let pvConservationPlotSectionEle = this.ctx.querySelector('.pvConservationPlotRow');
@@ -476,7 +488,7 @@ class LayoutHelper {
                     }else{
         
                         let variantGraphSectionEle = this.ctx.querySelector('.pvVariantGraphRow');
-                        if(variantGraphSectionEle) variantGraphSectionEle.style.display = 'table';
+                        if(variantGraphSectionEle) variantGraphSectionEle.style.display = 'flex';
         
                         if(variantGraphSectionEle.classList.contains('expanded')) variantGraphSectionEle.classList.remove('expanded');
                         let pvVariantPlotSectionEle = this.ctx.querySelector('.pvVariantPlotRow');
@@ -500,6 +512,8 @@ class LayoutHelper {
 
         //Close other open menus
         this.ctx.querySelector('.settingsMenu').style.display = 'none';
+        this.hideMoreOptions();
+        this.hideInfoTooltips();
         
         let menuBox = this.ctx.querySelector(`.rangeMenu`);
         if(menuBox.style.display == 'none'){
@@ -527,10 +541,56 @@ class LayoutHelper {
         }
     }
 
+    openMoreOptions(trackIndex, subtrackIndex){
+        //Close other open menus
+        this.ctx.querySelector('.settingsMenu').style.display = 'none';
+        this.ctx.querySelector('.rangeMenu').style.display = 'none';
+        this.hideInfoTooltips();
+
+        const menuBox = this.ctx.querySelector(`.moreOptionsMenu_${trackIndex}_${subtrackIndex}`);
+        if(menuBox.style.display == 'none') {
+            this.hideMoreOptions();
+            const moreOptions = menuBox.previousElementSibling.getBoundingClientRect();
+            menuBox.style.left = (moreOptions.x + moreOptions.width + 16) +'px';
+            menuBox.style.top = (moreOptions.y + -16) +'px';
+            menuBox.style.display = 'block';
+        } else {
+            menuBox.style.display = 'none';
+        }
+    }
+
+    showInfoTooltip(trackIndex, subtrackIndex){
+        //Close other open menus
+        this.ctx.querySelector('.settingsMenu').style.display = 'none';
+        this.ctx.querySelector('.rangeMenu').style.display = 'none';
+        this.hideInfoTooltips();
+        
+        const tooltipBox = this.ctx.querySelector(`.infoTooltip_${trackIndex}_${subtrackIndex}`);
+        const actionButton = this.ctx.querySelector(`.infoAction_${trackIndex}_${subtrackIndex}`).getBoundingClientRect();
+        tooltipBox.style.left = (actionButton.x + actionButton.width + 16) +'px';
+        tooltipBox.style.top = (actionButton.y + -16) +'px';
+        tooltipBox.style.display = 'block';
+        this.hideMoreOptions();
+    }
+    
+    hideMoreOptions(){
+        //Hide all more options menu
+        if(this.ctx)
+            [...this.ctx.querySelectorAll('.moreOptionsMenu')].forEach(m=>m.style.display = 'none');
+    }
+
+    hideInfoTooltips(){
+        //Hide all info tooltips
+        if(this.ctx)
+            [...this.ctx.querySelectorAll('.infoTooltip')].forEach(m=>m.style.display = 'none');
+    }
+
     openCategorySettingsMenu(){
 
         //Close other open menus
         this.ctx.querySelector('.rangeMenu').style.display = 'none';
+        this.hideMoreOptions();
+        this.hideInfoTooltips();
 
         let menuBox = this.ctx.querySelector(`.settingsMenu`);
         if(menuBox.style.display == 'none'){
@@ -588,31 +648,6 @@ class LayoutHelper {
         });
 
         this.openCategorySettingsMenu();
-    }
-
-    showLabelTooltip(e){
-        let tooltipContentEle = e.currentTarget.lastElementChild;
-        if(!tooltipContentEle || tooltipContentEle.className != "labelTooltipContent") return;
-
-        let toolTipText = tooltipContentEle.innerText;
-
-        let labelToolTipEle = this.ctx.querySelector(".labelTooltipBox");
-        
-        labelToolTipEle.innerHTML = toolTipText;
-
-        let labelCoordinates = e.currentTarget.getBoundingClientRect();
-
-        labelToolTipEle.style.left = (labelCoordinates.x + labelCoordinates.width + 5) +'px';
-
-       
-        labelToolTipEle.style.top = (labelCoordinates.y + 10) +'px';
-
-        labelToolTipEle.style.display = 'block';
-
-    }
-
-    hideLabelTooltip(){
-        this.ctx.querySelector(".labelTooltipBox").style.display = 'none';
     }
 
     showVariantPlot(){

--- a/src/helpers/layout.js
+++ b/src/helpers/layout.js
@@ -567,8 +567,8 @@ class LayoutHelper {
         
         const tooltipBox = this.ctx.querySelector(`.infoTooltip_${trackIndex}_${subtrackIndex}`);
         const actionButton = this.ctx.querySelector(`.infoAction_${trackIndex}_${subtrackIndex}`).getBoundingClientRect();
-        tooltipBox.style.left = (actionButton.x + actionButton.width + 16) +'px';
-        tooltipBox.style.top = (actionButton.y + -16) +'px';
+        tooltipBox.style.left = (actionButton.x + 24) +'px';
+        tooltipBox.style.top = (actionButton.y + -32) +'px';
         tooltipBox.style.display = 'block';
         this.hideMoreOptions();
     }

--- a/src/helpers/layout.js
+++ b/src/helpers/layout.js
@@ -104,7 +104,7 @@ class LayoutHelper {
     }
 
     getTrackHeight(trackDataLength, isOverlapping){
-        let eleHt = (trackDataLength > 1) ? 74 : 44
+        let eleHt = (trackDataLength > 2) ? 74 : 44
         return eleHt;
     }
 

--- a/src/helpers/layout.js
+++ b/src/helpers/layout.js
@@ -516,8 +516,11 @@ class LayoutHelper {
         this.hideInfoTooltips();
         
         let menuBox = this.ctx.querySelector(`.rangeMenu`);
+        const menuAction = menuBox.previousElementSibling.getBoundingClientRect();
         if(menuBox.style.display == 'none'){
-
+            menuBox.style.left = (menuAction.x + menuAction.width + 16) +'px';
+            menuBox.style.top = (menuAction.y + 16) +'px';
+            menuBox.style.display = 'block';
             let startEle = this.ctx.querySelector('.pvRangeMenuStart');
             let endEle = this.ctx.querySelector('.pvRangeMenuEnd');
             
@@ -593,7 +596,11 @@ class LayoutHelper {
         this.hideInfoTooltips();
 
         let menuBox = this.ctx.querySelector(`.settingsMenu`);
+        const menuAction = menuBox.previousElementSibling.getBoundingClientRect();
         if(menuBox.style.display == 'none'){
+            menuBox.style.left = (menuAction.x + menuAction.width + 16) +'px';
+            menuBox.style.top = (menuAction.y + 16) +'px';
+            menuBox.style.display = 'block';
             
             menuBox.querySelectorAll('.pvSectionChkBox').forEach((chkBox, chkBoxIndex) => {
                 if(this.ctx.hiddenSections.indexOf(chkBoxIndex) > -1){

--- a/src/protvista-pdb.js
+++ b/src/protvista-pdb.js
@@ -171,6 +171,11 @@ class ProtvistaPDB extends HTMLElement {
 
         document.querySelectorAll(".labelHighlightRight").forEach(el => {
             el.classList.remove("enabled");
+            const icon=el.children[0];
+            const text=el.children[1];
+            icon.classList.remove("icon-undo-alt");
+            icon.classList.add("icon-star");
+            text.innerText="Highlight fragments";
         });
 
         let fragments;
@@ -181,6 +186,11 @@ class ProtvistaPDB extends HTMLElement {
             const locFragments = flatten(subtrackData.locations.map(location => location.fragments));
 
             buttonEl.classList.add("enabled");
+            const icon=buttonEl.children[0];
+            const text=buttonEl.children[1];
+            icon.classList.remove("icon-star");
+            icon.classList.add("icon-undo-alt");
+            text.innerText="Undo highlight";
             fragments = locFragments.map(fragment => ({ ...fragment, feature: subtrackData }));
         } else {
             fragments = [];

--- a/src/protvista-pdb.js
+++ b/src/protvista-pdb.js
@@ -169,13 +169,20 @@ class ProtvistaPDB extends HTMLElement {
             .map(el => el.querySelector("protvista-pdb-track"))
             .filter(Boolean);
 
+        const changeIcon = (el, enabled) => {
+            if (enabled) el.classList.add("enabled");
+            else el.classList.remove("enabled");
+            const icon = el.children[0];
+            const text = el.children[1];
+            if (icon && text) {
+                icon.classList.remove(enabled ? "icon-star" : "icon-undo-alt");
+                icon.classList.add(enabled ? "icon-undo-alt" : "icon-star");
+                text.innerText = enabled ? "Undo highlight" : "Highlight fragments";
+            }
+        }
+
         document.querySelectorAll(".labelHighlightRight").forEach(el => {
-            el.classList.remove("enabled");
-            const icon=el.children[0];
-            const text=el.children[1];
-            icon.classList.remove("icon-undo-alt");
-            icon.classList.add("icon-star");
-            text.innerText="Highlight fragments";
+            changeIcon(el, false);
         });
 
         let fragments;
@@ -184,13 +191,7 @@ class ProtvistaPDB extends HTMLElement {
             const { trackIndex, subtrackIndex, subtrackData } = options;
             const buttonEl = this.querySelector(`.pvHighlight_${trackIndex}_${subtrackIndex}`);
             const locFragments = flatten(subtrackData.locations.map(location => location.fragments));
-
-            buttonEl.classList.add("enabled");
-            const icon=buttonEl.children[0];
-            const text=buttonEl.children[1];
-            icon.classList.remove("icon-star");
-            icon.classList.add("icon-undo-alt");
-            text.innerText="Undo highlight";
+            changeIcon(buttonEl, true);
             fragments = locFragments.map(fragment => ({ ...fragment, feature: subtrackData }));
         } else {
             fragments = [];

--- a/src/section-templates/navigation.js
+++ b/src/section-templates/navigation.js
@@ -42,7 +42,7 @@ function PDBePvNavSection(ctx) {
             <div class="settingsMenu viewMenuBox" style="display:none">
                 <div class="protvistaRangeMenuTitle">
                     <div>Hide sections</div>
-                    <span class="icon icon-functional protvistaMenuClose" data-icon="x" title="close" @click=${e => {e.stopPropagation();ctx.layoutHelper.openCategorySettingsMenu()}}></span>
+                    <span class="icon icon-functional protvistaMenuClose" data-icon="x" title="Close" @click=${e => {e.stopPropagation();ctx.layoutHelper.openCategorySettingsMenu()}}></span>
                 </div>
                 <div class="protvistaForm rangeForm" style="width:215px;max-height:400px;">
                     <table style="font-size:inherit;margin-bottom:0" class="pvHideOptionsTable">

--- a/src/section-templates/navigation.js
+++ b/src/section-templates/navigation.js
@@ -11,7 +11,7 @@ function PDBePvNavSection(ctx) {
 
             <!-- View / highlight menu -->
             <span class="protvistaToolbarIcon" title="Highlight / View region" @click=${e => ctx.layoutHelper.openRangeMenu()}>
-                <i class="icon icon-common icon-lightbulb"></i>
+                <i class="icon icon-common icon-star"></i>
             </span>
             <div class="rangeMenu viewMenuBox" style="display:none">
                 <div class="protvistaRangeMenuTitle">

--- a/src/section-templates/tracks.js
+++ b/src/section-templates/tracks.js
@@ -34,10 +34,10 @@ function PDBePvTracksSection(ctx) {
                                 <span class="icon icon-common icon-search-plus"></span>
                                 <span>Zoom in</span>
                             </button>
-                            <button type="button" class="more-options-action infoAction_${trackIndex}_${subtrackIndex}" @click=${e => ctx.layoutHelper.showInfoTooltip(trackIndex, subtrackIndex)}>
+                            ${subtrackData.help ? html`<button type="button" class="more-options-action infoAction_${trackIndex}_${subtrackIndex}" @click=${e => ctx.layoutHelper.showInfoTooltip(trackIndex, subtrackIndex)}>
                                 <span class="icon icon-common icon-info"></span>
                                 More info
-                            </button>
+                            </button>` : ""}
                             <button type="button" class="more-options-action" @click=${e => {e.stopPropagation();ctx.layoutHelper.hideSubTrack(trackIndex, subtrackIndex)}}>
                                 <span class="icon icon-common icon-eye-slash"></span>
                                 Hide
@@ -46,8 +46,8 @@ function PDBePvTracksSection(ctx) {
                         <!--More options menu end-->
                         <!--Info tooltip-->
                             <div class="infoTooltip viewMenuBox infoTooltip_${trackIndex}_${subtrackIndex}">
+                                <div class="info-header"><span class="title">${subtrackData.label}</span><span class="icon icon-common icon-close" @click=${e => ctx.layoutHelper.hideInfoTooltips()}></span></div>
                                 ${subtrackData.help}
-                                <span class="label-tooltip">${subtrackData.labelTooltip}</span>
                             </div>
                         <!--Info tooltip end-->
                     </div>

--- a/src/section-templates/tracks.js
+++ b/src/section-templates/tracks.js
@@ -21,26 +21,35 @@ function PDBePvTracksSection(ctx) {
         <div class="protvistaRowGroup pvSubtracks_${trackIndex}">
             ${trackData.data.map((subtrackData, subtrackIndex) => html`
                 <div class="protvistaRow pvSubtrackRow_${trackIndex}_${subtrackIndex}">
-                    <div class="protvistaCol1 track-label" style=${styleMap(subtrackData.labelColor ? {backgroundColor: subtrackData.labelColor, borderBottom: '1px solid lightgrey'} : {})}
-                    @mouseover=${e => {e.stopPropagation();ctx.layoutHelper.showLabelTooltip(e)}} @mouseout=${e => {e.stopPropagation();ctx.layoutHelper.hideLabelTooltip()}}>
-                        <span class="icon icon-functional hideLabelIcon" data-icon="x" @click=${e => {e.stopPropagation();ctx.layoutHelper.hideSubTrack(trackIndex, subtrackIndex)}} 
-                        title="Hide this section"></span> 
-                        <div class="pvSubtrackLabel_${trackIndex}_${subtrackIndex}" style="word-break: break-all;"></div>
-
-                        <span
-                            class="icon icon-functional ${getHighlightClass(ctx, trackIndex, subtrackIndex)}"
-                            data-icon="4"
-                            @click=${(ev) => highlightSubtrackFragments(ctx, trackIndex, subtrackIndex, subtrackData)}
-                            title="Click to highlight all fragments in subtrack"
-                        ></span>
-
-                        <span class="icon icon-functional labelZoomIconRight pvZoomIcon_${trackIndex}_${subtrackIndex}" data-icon="1" @click="${e => { ctx.layoutHelper.zoomTrack({start:1, end: null, trackData: subtrackData}, trackIndex+'_'+subtrackIndex); }}
-                        title="Click to zoom-out this section"></span>
-
-                        ${subtrackData.labelTooltip ? html`
-                            <span class="labelTooltipContent" style="display:none;">${subtrackData.labelTooltip}</span>
-                        ` : ``}
-                        ${help("subtrack-help", subtrackData.help)}
+                    <div class="protvistaCol1 track-label" style=${styleMap(subtrackData.labelColor ? {backgroundColor: subtrackData.labelColor, borderBottom: '1px solid lightgrey'} : {})}>
+                        <div class="pvSubtrackLabel_${trackIndex}_${subtrackIndex}" title="${subtrackData.label}"></div>
+                        <button type="button" class="more-options" title="Show options" @click=${e => ctx.layoutHelper.openMoreOptions(trackIndex, subtrackIndex)}><i class="icon icon-common icon-ellipsis-h"></i></button>
+                        <!--More options menu-->
+                        <div class="moreOptionsMenu viewMenuBox moreOptionsMenu_${trackIndex}_${subtrackIndex}" style="display:none">
+                            <button type="button" class="more-options-action ${getHighlightClass(ctx, trackIndex, subtrackIndex)}" @click=${(ev) => highlightSubtrackFragments(ev, ctx, trackIndex, subtrackIndex, subtrackData)}>
+                                <span class="icon icon-common icon-star"></span>
+                                <span>Highlight fragments</span>
+                            </button>
+                            <button type="button" class="more-options-action pvZoomIcon_${trackIndex}_${subtrackIndex}" @click=${e => { ctx.layoutHelper.zoomTrack({start:1, end: null, trackData: subtrackData}, trackIndex+'_'+subtrackIndex); }}>
+                                <span class="icon icon-common icon-search-plus"></span>
+                                <span>Zoom in</span>
+                            </button>
+                            <button type="button" class="more-options-action infoAction_${trackIndex}_${subtrackIndex}" @click=${e => ctx.layoutHelper.showInfoTooltip(trackIndex, subtrackIndex)}>
+                                <span class="icon icon-common icon-info"></span>
+                                More info
+                            </button>
+                            <button type="button" class="more-options-action" @click=${e => {e.stopPropagation();ctx.layoutHelper.hideSubTrack(trackIndex, subtrackIndex)}}>
+                                <span class="icon icon-common icon-eye-slash"></span>
+                                Hide
+                            </button>
+                        </div>
+                        <!--More options menu end-->
+                        <!--Info tooltip-->
+                            <div class="infoTooltip viewMenuBox infoTooltip_${trackIndex}_${subtrackIndex}">
+                                ${subtrackData.help}
+                                <span class="label-tooltip">${subtrackData.labelTooltip}</span>
+                            </div>
+                        <!--Info tooltip end-->
                     </div>
                     <div class="protvistaCol2 track-content" style=${styleMap(trackData.labelColor ? {borderBottom: '1px solid lightgrey'} : {})}>
                         <protvista-pdb-track class="pvSubtrack_${trackIndex}" length="${ctx.viewerData.length}" layout="${ctx.layoutHelper.getTrackLayout(subtrackData.overlapping)}" height="${ctx.layoutHelper.getTrackHeight(subtrackData.locations.length, subtrackData.overlapping)}"></protvista-pdb-track>
@@ -52,11 +61,11 @@ function PDBePvTracksSection(ctx) {
     `)}`
 }
 
-function highlightSubtrackFragments(ctx, trackIndex, subtrackIndex, subtrackData) {
+function highlightSubtrackFragments(ev, ctx, trackIndex, subtrackIndex, subtrackData) {
     const buttonEl = ctx.querySelector(`.pvHighlight_${trackIndex}_${subtrackIndex}`);
     const isEnabled = buttonEl ? !buttonEl.classList.contains("enabled") : true;
     ctx.setSubtrackFragmentsSelection({ isEnabled, trackIndex, subtrackIndex, subtrackData })
-
+    
 }
 
 function renderAddButton(ctx, trackData) {
@@ -83,24 +92,12 @@ function getHighlightClass(ctx, trackIndex, subtrackIndex) {
         isHighlighted ? "enabled" : "",
     ]
 
-    return classes.filter(Boolean).join(" ");
+    return classes.filter(Boolean).join(" ");    
 }
 
 function onAddEvent(ctx, trackData, ev) {
     stopEvent(ev);
     ctx.fireActionEvent({ type: "add", trackId: trackData.id });
-}
-
-function help(className, message) {
-    if (!message) return;
-
-    return html`
-        <button
-            class="${className}"
-            title="${message}"
-            @click=${stopEvent}
-        >?</button>
-    `;
 }
 
 function stopEvent(ev) {

--- a/src/section-templates/tracks.js
+++ b/src/section-templates/tracks.js
@@ -46,7 +46,7 @@ function PDBePvTracksSection(ctx) {
                         <!--More options menu end-->
                         <!--Info tooltip-->
                             <div class="infoTooltip viewMenuBox infoTooltip_${trackIndex}_${subtrackIndex}">
-                                <div class="info-header"><span class="title">${subtrackData.label}</span><span class="icon icon-common icon-close" @click=${e => ctx.layoutHelper.hideInfoTooltips()}></span></div>
+                                <div class="info-header"><span class="title">${subtrackData.label}</span><span class="icon icon-common icon-close" title="Close" @click=${e => ctx.layoutHelper.hideInfoTooltips()}></span></div>
                                 ${subtrackData.help}
                             </div>
                         <!--Info tooltip end-->

--- a/src/section-templates/tracks.js
+++ b/src/section-templates/tracks.js
@@ -5,12 +5,12 @@ function PDBePvTracksSection(ctx) {
     return html `${ctx.viewerData.tracks.map((trackData, trackIndex) => html`
         <div class="protvistaRow pvTrackRow pvTracks_${trackIndex}">
             <div class="protvistaCol1 category-label" data-label-index="${trackIndex}" @click=${e => ctx.layoutHelper.showSubtracks(trackIndex)} 
-            style=${styleMap(trackData.labelColor ? {backgroundColor: trackData.labelColor, borderBottom: '1px solid lightgrey'} : {})}>
+            style=${styleMap(trackData.labelColor ? {backgroundColor: trackData.labelColor, borderBottom: '1px solid lightgrey'} : {})}
+            title="${trackData.label}: ${trackData.help}">
                 <span class="pvTrackLabel_${trackIndex}"></span>
                 <span class="protvistaResetSectionIcon pvResetSection_${trackIndex}" @click=${e => {e.stopPropagation();ctx.layoutHelper.resetSection(trackIndex)}} title="Reset section">
-                <i class="icon icon-functional" data-icon="R"></i>
+                    <i class="icon icon-functional" data-icon="R"></i>
                 </span>
-                ${help("track-help", trackData.help)}
                 ${renderAddButton(ctx, trackData)}
             </div>
             <div class="protvistaCol2 aggregate-track-content" style=${styleMap(trackData.labelColor ? {borderBottom: '1px solid lightgrey'} : {})}>

--- a/src/section-templates/tracks.js
+++ b/src/section-templates/tracks.js
@@ -8,9 +8,7 @@ function PDBePvTracksSection(ctx) {
             style=${styleMap(trackData.labelColor ? {backgroundColor: trackData.labelColor, borderBottom: '1px solid lightgrey'} : {})}
             title="${trackData.label}: ${trackData.help}">
                 <span class="pvTrackLabel_${trackIndex}"></span>
-                <span class="protvistaResetSectionIcon pvResetSection_${trackIndex}" @click=${e => {e.stopPropagation();ctx.layoutHelper.resetSection(trackIndex)}} title="Reset section">
-                    <i class="icon icon-functional" data-icon="R"></i>
-                </span>
+                <button type="button" class="protvistaResetSectionIcon pvResetSection_${trackIndex}" title="Reset section" @click=${e => {e.stopPropagation();ctx.layoutHelper.resetSection(trackIndex)}}><i class="icon icon-common icon-redo-alt"></i></button>
                 ${renderAddButton(ctx, trackData)}
             </div>
             <div class="protvistaCol2 aggregate-track-content" style=${styleMap(trackData.labelColor ? {borderBottom: '1px solid lightgrey'} : {})}>

--- a/styles/protvista-pdb.css
+++ b/styles/protvista-pdb.css
@@ -197,6 +197,7 @@
     padding: 1rem;
     box-sizing: border-box;
     min-width: 200px;
+    cursor: default;
 }
 
 .infoTooltip .info-header {
@@ -207,13 +208,20 @@
 }
 
 .infoTooltip .info-header .icon-close {
+    align-self: flex-start;
     margin-bottom: 0.25em;
 }
 
-.infoTooltip .title {
+.infoTooltip .info-header .icon-close:hover {
+    color: #555;
+}
+
+.protvistaCol1 .infoTooltip .title {
     font-size: 1.15em;
     font-weight: bold;
     display: block;
+    margin-right: 0.25em;
+    white-space: inherit;
 }
 
 .more-options-action:hover {background-color: #e1e1e1;}

--- a/styles/protvista-pdb.css
+++ b/styles/protvista-pdb.css
@@ -187,12 +187,27 @@
     position: fixed;
     left: 0;
     top: 0;
-    padding: 1.5rem;
+    padding: 1rem;
     box-sizing: border-box;
     min-width: 200px;
 }
 
-.label-tooltip {color:red}
+.infoTooltip .info-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 0.5em;
+}
+
+.infoTooltip .info-header .icon-close {
+    margin-bottom: 0.25em;
+}
+
+.infoTooltip .title {
+    font-size: 1.15em;
+    font-weight: bold;
+    display: block;
+}
 
 .more-options-action:hover {background-color: #e1e1e1;}
 .more-options-action:active {background-color: #cfcfcf;}

--- a/styles/protvista-pdb.css
+++ b/styles/protvista-pdb.css
@@ -11,29 +11,38 @@
 
 
 .protvistaRow {
-    display: table;
+    display: flex;
     width: 100%;
-    clear: both;
 }
 
 .protvistaCol1 {
-    display: table-cell;
-    vertical-align: middle;
+    display: flex;
+    align-items: center;
+    min-width: 15%;
     width: 15%;
-    font-size:90%;
+    max-width: 15%;
+    font-size: 90%;
+    padding: 0 .75em;
+}
+
+.protvistaCol1 span:first-child {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .protvistaCol2 {
-    display: table-cell;
     width: 85%;
     overflow: hidden;
     padding-left: 10px;
 }
 
-@media (max-width: 1800px) {
+@media (max-width: 2000px) {
     .protvistaCol1 {
+        min-width: 20%;
         width: 20%;
-        font-size:90%;
+        max-width: 20%;
+        font-size: .9em;
     }
     .protvistaCol2 {
         width: 80%;
@@ -42,8 +51,10 @@
 
 @media (max-width: 1400px) {
     .protvistaCol1 {
+        min-width: 22%;
         width: 22%;
-        font-size:90%;
+        max-width: 22%;
+        font-size: .9em;
     }
     .protvistaCol2 {
         width: 78%;
@@ -52,8 +63,10 @@
 
 @media (max-width: 1100px) {
     .protvistaCol1 {
+        min-width: 25%;
         width: 25%;
-        font-size:75%;
+        max-width: 25%;
+        font-size: .75em;
     }
     .protvistaCol2 {
         width: 75%;
@@ -62,8 +75,10 @@
 
 @media (max-width: 1000px) {
     .protvistaCol1 {
+        min-width: 27%;
         width: 27%;
-        font-size:70%;
+        max-width: 27%;
+        font-size: .7em;
     }
     .protvistaCol2 {
         width: 73%;
@@ -72,8 +87,10 @@
 
 @media (max-width: 767px) {
     .protvistaCol1 {
+        min-width: 30%;
         width: 30%;
-        font-size:70%;
+        max-width: 30%;
+        font-size: .7em;
     }
     .protvistaCol2 {
         width: 70%;
@@ -85,7 +102,6 @@
     border-bottom: 1px solid #fff;
     background-color: #b2f5ff;
     cursor: pointer;
-    padding: .8em 1.3em .8em .8em;
     position: relative;
 }
 
@@ -141,10 +157,6 @@
     /* Safari */
     transition: opacity .1s;
     border-bottom: 1px solid #b2f5ff;
-}
-
-.aggregate-track-content{
-    padding-bottom: 5px;
 }
 
 .track-label, .track-content {
@@ -257,7 +269,7 @@
 }
 
 .protvistaToolbar{
-    text-align: right;
+    justify-content: center;
 }
 
 .protvistaToolbarIcon{

--- a/styles/protvista-pdb.css
+++ b/styles/protvista-pdb.css
@@ -160,10 +160,11 @@
     white-space: nowrap;
 }
 
-.more-options:hover {background-color: #e1e1e1;}
-.more-options:active {background-color: #cfcfcf;}
+.category-label span[class^=pvTrackLabel] {
+    flex-grow: 1;
+}
 
-.more-options {
+.protvistaResetSectionIcon, .more-options {
     all: unset;
     background-color: #ffffff;
     border: 1px solid #d6d6d6;
@@ -171,6 +172,12 @@
     color: #6d6d6d;
     padding: .125em .5em;
     margin-left: 1em;
+}
+
+.protvistaResetSectionIcon:hover, .more-options:hover {background-color: #e1e1e1;}
+.protvistaResetSectionIcon:active, .more-options:active {background-color: #cfcfcf;}
+.protvistaResetSectionIcon {
+    display: none;
 }
 
 .moreOptionsMenu.viewMenuBox {
@@ -302,27 +309,6 @@
 
 .protvistaRowGroup.noPaddingRight > .protvistaRow > .protvistaCol2 {
     padding-right: 0 !important;
-}
-
-.protvistaResetSectionIcon{
-    position: absolute;
-    border: 1px solid #828181;
-    background-color: #828181;
-    border-radius: 50%;
-    cursor: pointer;
-    text-align: center;
-    text-align: center;
-    width: 20px;
-    height: 20px;
-    line-height: 19px;
-    right: 10px;
-    display: none;
-}
-
-.protvistaResetSectionIcon i{
-    color: #fff;
-    cursor: pointer;
-    font-size:80%;
 }
 
 .protvistaToolbar{

--- a/styles/protvista-pdb.css
+++ b/styles/protvista-pdb.css
@@ -691,11 +691,11 @@ ul.filter-list a {
 
 .viewMenuBox {
     display: block;
-    position: absolute;
+    position: fixed;
     z-index: 1;
     background: #fff;
-    left: 70%;
-    top: 47px;
+    left: 0;
+    top: 0;
     min-width: 150px;
     max-width: 280px;
     overflow: auto;

--- a/styles/protvista-pdb.css
+++ b/styles/protvista-pdb.css
@@ -111,7 +111,6 @@
     border-bottom: 1px solid #fff;
     background-color: #b2f5ff;
     cursor: pointer;
-    position: relative;
 }
 
 .category-label:hover {
@@ -150,9 +149,67 @@
 
 .track-label {
     background-color: #d9faff;
-    padding: 0.5em 1.2em 0.5em 1.8em;
+    padding: 0 1em;
     cursor:pointer;
-    position: relative;
+    justify-content: space-between;
+}
+
+.track-label div[class^=pvSubtrackLabel] {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.more-options:hover {background-color: #e1e1e1;}
+.more-options:active {background-color: #cfcfcf;}
+
+.more-options {
+    all: unset;
+    background-color: #ffffff;
+    border: 1px solid #d6d6d6;
+    border-radius: .5em;
+    color: #6d6d6d;
+    padding: .125em .5em;
+    margin-left: 1em;
+}
+
+.moreOptionsMenu.viewMenuBox {
+    position: fixed;
+    left: 0;
+    top: 0;
+    padding: 0.25rem 0;
+    box-sizing: border-box;
+    min-width: 200px;
+}
+
+.infoTooltip.viewMenuBox {
+    display: none;
+    position: fixed;
+    left: 0;
+    top: 0;
+    padding: 1.5rem;
+    box-sizing: border-box;
+    min-width: 200px;
+}
+
+.label-tooltip {color:red}
+
+.more-options-action:hover {background-color: #e1e1e1;}
+.more-options-action:active {background-color: #cfcfcf;}
+
+.more-options-action {
+    all: unset;
+    display: flex;
+    align-items: center;
+    width: 100%;
+    padding-right: 1rem;
+    box-sizing: border-box;
+    color: #242424;
+}
+
+.more-options-action .icon {
+    display: inline-block;
+    padding: .5rem 1rem;
 }
 
 .category-label.pdbIconsLabel, .track-label.pdbIconsLabel {
@@ -230,31 +287,6 @@
 
 .protvistaRowGroup.noPaddingRight > .protvistaRow > .protvistaCol2 {
     padding-right: 0 !important;
-}
-
-.labelZoomIcon{
-    position: absolute;
-    left: 5px;
-    cursor: zoom-in;
-    color: #848a86;
-    top: 50%;
-    transform: translateY(-50%);
-    font-size: 12px;
-}
-
-.labelZoomIcon.active{
-    cursor: zoom-out!important;
-    color: #009e38!important;
-}
-
-.hideLabelIcon{
-    position: absolute;
-    right: 5px;
-    cursor: pointer;
-    color: #848a86;
-    top: 10%;
-    transform: translateY(-10%);
-    font-size: 10px;
 }
 
 .protvistaResetSectionIcon{

--- a/styles/protvista-pdb.css
+++ b/styles/protvista-pdb.css
@@ -22,7 +22,16 @@
     width: 15%;
     max-width: 15%;
     font-size: 90%;
-    padding: 0 .75em;
+    padding: 0 1em;
+    min-height: 45px;
+}
+
+.protvistaRow:not(.expanded) > .category-label:not(:hover) span::selection {
+    background: #9e9e9e;
+}
+
+.protvistaRow.expanded > .category-label span::selection, .category-label:hover span::selection {
+    background: #253e4b;
 }
 
 .protvistaCol1 span:first-child {
@@ -110,17 +119,15 @@
 }
 
 .category-label::before {
-    content: ' ';
+    content: '';
     display: inline-block;
-    width: 0;
-    height: 0;
+    width: 10px;
+    height: 10px;
     border-top: 5px solid transparent;
     border-bottom: 5px solid transparent;
     border-left: 5px solid #333;
-    margin-right: 5px;
-    -webkit-transition: all .1s;
-    /* Safari */
-    transition: all .1s;
+    margin-right: .5em;
+    box-sizing: border-box;
 }
 
 .protvistaRow.expanded > .category-label {
@@ -128,14 +135,17 @@
 }
 
 .protvistaRow.expanded > .category-label::before {
-    content: ' ';
+    content: '';
     display: inline-block;
-    width: 0;
-    height: 0;
+    width: 10px;
+    height: 10px;
+    margin-top: 3px;
+    margin-left: -2px;
     border-left: 5px solid transparent;
     border-right: 5px solid transparent;
     border-top: 5px solid #333;
-    margin-right: 5px;
+    margin-right: calc(.5em + 2px);
+    box-sizing: border-box;
 }
 
 .track-label {

--- a/styles/protvista-pdb.css
+++ b/styles/protvista-pdb.css
@@ -210,6 +210,7 @@
 .infoTooltip .info-header .icon-close {
     align-self: flex-start;
     margin-bottom: 0.25em;
+    cursor: pointer;
 }
 
 .infoTooltip .info-header .icon-close:hover {


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/865cm3qjj

### :memo: Implementation

- Relocate tracks vertically in the center, so they perfectly fit in the track view
- Make tracks taller only when more than 2 fragments sharing same position of the sequence (previous was when more than 1)
- Move track actions on a tooltip (hide when leaves the protvista-pdb frame)
- Change button icons and descriptions
- View and hide tooltips set position as fixed (calculated position) so no longer tooltip cuts
- Set the display of the layout of the tracks as flex, aligned center with fixed width on the labels container
- Toggle highlight and zoom icons (resets on other tracks)
- Removed `labelTooltip`
- Display the name/help on hover as title attribute

### :art: Screenshots

Tracks height **BEFORE**:

![image](https://github.com/EyeSeeTea/protvista-pdb/assets/43061485/061f2acf-bde6-4acf-88d7-6300fd1a7f81)

Tracks height **AFTER**:

![image](https://github.com/EyeSeeTea/protvista-pdb/assets/43061485/5c3f618e-7bb1-4100-acea-c9f6e7c0966b)

New layout demo:

![3dbio](https://github.com/EyeSeeTea/protvista-pdb/assets/43061485/d956b765-bc19-4da0-8d63-5bd99664a2a8)
