### PR TITLE
Highlights on NavigationBar, sync events with molstar and other instances of protvista-pdb

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@3dbionotes/protvista-pdb",
-  "version": "2.0.1-estv1",
+  "version": "2.0.1-est-1-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@3dbionotes/protvista-pdb",
-      "version": "2.0.1-estv1",
+      "version": "2.0.1-est-1-beta.1",
       "license": "Apache 2.0",
       "dependencies": {
         "lodash-es": "^4.17.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@3dbionotes/protvista-pdb",
-  "version": "2.0.1-estv1",
+  "version": "2.0.1-est-1-beta.1",
   "description": "PDB ProtVista Viewer",
   "files": [
     "dist",

--- a/publish-npm-package
+++ b/publish-npm-package
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e -u
+
+if ! test -z "$(git status -uno --porcelain | grep -v extendProtVista)"; then
+    echo "Uncommited changes"
+    git status
+    exit 1
+fi
+
+version=$(cat package.json | jq -r '.version')
+npm install
+npm run build
+publish_opts=$(echo $version | grep -q beta && echo "--tag beta" || true)
+yarn publish $publish_opts --new-version $version .
+git tag $version -f
+git push
+git push --tags

--- a/src/custom-pv-components/pdb-navigation.js
+++ b/src/custom-pv-components/pdb-navigation.js
@@ -108,6 +108,9 @@ class ProtvistaPdbNavigation extends ProtvistaNavigation {
       .attr("opacity", 0.4)
       .attr("height", height);
 
+    this._highlightFragments = this._svg
+      .append("g");
+
     this._updateNavRuler();
 
     const resize = () => { this._onResize(); this.highlightInterval(); };
@@ -118,7 +121,7 @@ class ProtvistaPdbNavigation extends ProtvistaNavigation {
     }
     window.addEventListener("resize", resize);
     window.addEventListener("protvista-highlight", ev => this.highlightInterval(ev));
-    window.addEventListener("protvista-mouseout", () => this.removeHighlightInterval());
+    window.addEventListener("protvista-remove-highlight", () => this.removeHighlightInterval());
   }
 
   highlightInterval(ev) {
@@ -141,6 +144,34 @@ class ProtvistaPdbNavigation extends ProtvistaNavigation {
       .attr("y", undefined)
       .attr("x", undefined)
       .attr("width", undefined);
+  }
+
+  highlightFragments() {
+    const intervalsString = (":10-20,50-60,110-200" || "").split(":")[1] || "";
+
+    const intervals = intervalsString.split(",").filter(Boolean).map(ns => {
+      const [start, end] = ns.split("-").map(s => parseInt(s));
+      return { start, end };
+    })
+
+    if (!this._highlightFragments) return;
+
+    const selection = this._highlightFragments
+      .selectAll("rect.hi")
+      .data(intervals)
+
+    selection.exit().remove()
+
+    selection.enter()
+      .append("rect")
+      .merge(selection)
+      .attr("class", "hi")
+      .attr("fill", "rgba(255, 145, 0, 0.8)")
+      .attr('stroke', 'black')
+      .attr("height", this._height)
+      .attr("x", interval => this.getXFromSeqPosition(interval.start))
+      .style("opacity", 0.3)
+      .attr("width", interval => this.getSingleBaseWidth() * (interval.end - interval.start + 1))
   }
 
 }

--- a/src/custom-pv-components/pdb-navigation.js
+++ b/src/custom-pv-components/pdb-navigation.js
@@ -18,17 +18,25 @@ const height = 40,
 
 class ProtvistaPdbNavigation extends ProtvistaNavigation {
 
+  getIntAttribute(attribute) {
+    return parseInt(this.getAttribute(attribute));
+  }
+
+  getFloatAttribute(attribute) {
+    return parseFloat(this.getAttribute(attribute));
+  }
+
   connectedCallback() {
     this.style.display = 'block';
     this.style.width = '100%';
     this.width = this.offsetWidth;
 
-    this._offset = parseFloat(this.getAttribute('offset')) || 0;
-    this._length = parseInt(this.getAttribute('length'));
-    this._displaystart = parseInt(this.getAttribute('displaystart')) || (this._offset > 0) ? this._offset : 1;
-    this._displayend = parseInt(this.getAttribute('displayend')) || (this._offset > 0) ? (this._length + this._offset - 1) : this._length;
-    this._highlightstart = parseInt(this.getAttribute('highlightstart'));
-    this._highlightend = parseInt(this.getAttribute('highlightend'));
+    this._offset = this.getFloatAttribute('offset') || 0;
+    this._length = this.getIntAttribute('length');
+    this._displaystart = this.getIntAttribute('displaystart') || (this._offset > 0) ? this._offset : 1;
+    this._displayend = this.getIntAttribute('displayend') || (this._offset > 0) ? (this._length + this._offset - 1) : this._length;
+    this._highlightstart = this.getIntAttribute('highlightstart');
+    this._highlightend = this.getIntAttribute('highlightend');
     this._highlightintervals = this.getAttribute("highlightintervals");
 
     this._highlightedFragments = [];
@@ -44,13 +52,9 @@ class ProtvistaPdbNavigation extends ProtvistaNavigation {
   }
 
   attributeChangedCallback(name, oldValue, newValue) {
-    if (oldValue !== newValue) {
-      if (name === "highlightintervals") this[`_${name}`] = newValue;
-      else if (name === "offset") this[`_${name}`] = parseFloat(newValue);
-      else this[`_${name}`] = parseInt(newValue);
-
-      this._updateNavRuler();
-    }
+    if (oldValue === newValue) return;
+    this[`_${name}`] = name === "highlightintervals" ? newValue : name === "offset" ? parseFloat(newValue) : parseInt(newValue);
+    this._updateNavRuler();
   }
 
   _onResize() {
@@ -144,7 +148,6 @@ class ProtvistaPdbNavigation extends ProtvistaNavigation {
       .attr('class', 'zoom-polygon')
       .attr('fill', '#777')
       .attr('fill-opacity','0.3');
-
 
     this._updateNavRuler();
 

--- a/src/custom-pv-components/pdb-navigation.js
+++ b/src/custom-pv-components/pdb-navigation.js
@@ -39,6 +39,22 @@ class ProtvistaPdbNavigation extends ProtvistaNavigation {
     this._createNavRuler();
   }
 
+  _onResize() {
+    this.width = this.offsetWidth;
+    if (this.width - padding.right < 0) return; //rect cannot have negative width
+    this._x = this._x.range([padding.left, this.width - padding.right]);
+
+    this._svg.attr('width', this.width);
+
+    this._axis.call(this._xAxis);
+
+    this._viewport.extent([[padding.left, 0], [this.width - padding.right, height * 0.51]]);
+
+    this._brushG.call(this._viewport);
+
+    this._updateNavRuler();
+  }
+
   _createNavRuler() {
 
     let scaleStart = (this._offset > 0) ? this._offset : 1;
@@ -139,6 +155,7 @@ class ProtvistaPdbNavigation extends ProtvistaNavigation {
     } else if (!(this._highlightStart >= 0 && this._highlightEnd >= 0)) return;
     if (this._x(this._highlightEnd) - this._x(this._highlightStart) < 0) return;
     const width = Math.max(1, this._x(this._highlightEnd) - this._x(this._highlightStart));
+    if (!ev && width !== 1) return;
     this._highlighted
       .attr("y", 0)
       .attr("x", this._x(this._highlightStart))

--- a/src/custom-pv-components/pdb-navigation.js
+++ b/src/custom-pv-components/pdb-navigation.js
@@ -130,10 +130,10 @@ class ProtvistaPdbNavigation extends ProtvistaNavigation {
 
   highlightInterval(ev) {
     if (ev) {
-      if (!(ev.detail.start && ev.detail.end)) return;
+      if (!(ev.detail.start >= 0 && ev.detail.end >= 0)) return;
       this._highlightStart = ev.detail.start;
       this._highlightEnd = ev.detail.end;
-    } else if (!(this._highlightStart && this._highlightEnd)) return;
+    } else if (!(this._highlightStart >= 0 && this._highlightEnd >= 0)) return;
     if (this._x(this._highlightEnd) - this._x(this._highlightStart) < 0) return;
     const width = Math.max(1, this._x(this._highlightEnd) - this._x(this._highlightStart));
     this._highlighted

--- a/src/custom-pv-components/pdb-navigation.js
+++ b/src/custom-pv-components/pdb-navigation.js
@@ -91,18 +91,6 @@ class ProtvistaPdbNavigation extends ProtvistaNavigation {
         }
       });
 
-    this._brushG = this._svg.append("g")
-      .attr("class", "brush")
-      .call(this._viewport);
-
-    this._brushG
-      .call(this._viewport.move, [this._x(this._displaystart), this._x(this._displayend)]);
-
-    this.polygon = this._svg.append("polygon")
-      .attr('class', 'zoom-polygon')
-      .attr('fill', '#777')
-      .attr('fill-opacity','0.3');
-
     this._highlighted = this._svg
       .append("rect")
       .attr("class", "highlighted")
@@ -112,6 +100,21 @@ class ProtvistaPdbNavigation extends ProtvistaNavigation {
 
     this._fragmentsGroup = this._svg
       .append("g");
+
+    this._brushG = this._svg.append("g")
+      .attr("class", "brush")
+      .call(this._viewport);
+
+    this._brushG
+      .call(this._viewport.move, [this._x(this._displaystart), this._x(this._displayend)]);
+
+    this._brushG.select(".selection").attr('stroke', '');
+
+    this.polygon = this._svg.append("polygon")
+      .attr('class', 'zoom-polygon')
+      .attr('fill', '#777')
+      .attr('fill-opacity','0.3');
+
 
     this._updateNavRuler();
 

--- a/src/custom-pv-components/pdb-navigation.js
+++ b/src/custom-pv-components/pdb-navigation.js
@@ -33,8 +33,8 @@ class ProtvistaPdbNavigation extends ProtvistaNavigation {
 
     this._offset = this.getFloatAttribute('offset') || 0;
     this._length = this.getIntAttribute('length');
-    this._displaystart = this.getIntAttribute('displaystart') || (this._offset > 0) ? this._offset : 1;
-    this._displayend = this.getIntAttribute('displayend') || (this._offset > 0) ? (this._length + this._offset - 1) : this._length;
+    this._displaystart = this.getIntAttribute('displaystart') || ((this._offset > 0) ? this._offset : 1);
+    this._displayend = this.getIntAttribute('displayend') || ((this._offset > 0) ? (this._length + this._offset - 1) : this._length);
     this._highlightstart = this.getIntAttribute('highlightstart');
     this._highlightend = this.getIntAttribute('highlightend');
     this._highlightintervals = this.getAttribute("highlightintervals");

--- a/src/custom-pv-components/pdb-navigation.js
+++ b/src/custom-pv-components/pdb-navigation.js
@@ -24,14 +24,14 @@ class ProtvistaPdbNavigation extends ProtvistaNavigation {
     this.width = this.offsetWidth;
 
     this._offset = parseFloat(this.getAttribute('offset')) || 0;
-    this._length = parseFloat(this.getAttribute('length'));
-    this._displaystart = parseFloat(this.getAttribute('displaystart')) || (this._offset > 0) ? this._offset : 1;
-    this._displayend = parseFloat(this.getAttribute('displayend')) || (this._offset > 0) ? (this._length + this._offset - 1) : this._length;
-    this._highlightstart = parseFloat(this.getAttribute('highlightstart'));
-    this._highlightend = parseFloat(this.getAttribute('highlightend'));
+    this._length = parseInt(this.getAttribute('length'));
+    this._displaystart = parseInt(this.getAttribute('displaystart')) || (this._offset > 0) ? this._offset : 1;
+    this._displayend = parseInt(this.getAttribute('displayend')) || (this._offset > 0) ? (this._length + this._offset - 1) : this._length;
+    this._highlightstart = parseInt(this.getAttribute('highlightstart'));
+    this._highlightend = parseInt(this.getAttribute('highlightend'));
     this._highlightintervals = this.getAttribute("highlightintervals");
 
-    this._highlightFragments = [];
+    this._highlightedFragments = [];
 
     this._onResize = this._onResize.bind(this);
     this._updateNavRuler = this._updateNavRuler.bind(this);
@@ -46,7 +46,8 @@ class ProtvistaPdbNavigation extends ProtvistaNavigation {
   attributeChangedCallback(name, oldValue, newValue) {
     if (oldValue !== newValue) {
       if (name === "highlightintervals") this[`_${name}`] = newValue;
-      else this[`_${name}`] = parseFloat(newValue);
+      else if (name === "offset") this[`_${name}`] = parseFloat(newValue);
+      else this[`_${name}`] = parseInt(newValue);
 
       this._updateNavRuler();
     }
@@ -175,23 +176,23 @@ class ProtvistaPdbNavigation extends ProtvistaNavigation {
     }
   }
 
-  removeHighlightFragments() {
-    if (this._highlightFragments && this._highlightFragments.length > 0)
-      this._highlightFragments.forEach(rect => rect.remove());
+  _removeHighlightFragments() {
+    if (this._highlightedFragments && this._highlightedFragments.length > 0)
+      this._highlightedFragments.forEach(rect => rect.remove());
   }
 
   _updateActiveHighlight() {
     const intervalsString = (this._highlightintervals || "").split(":")[1] || "";
-    if (!Boolean(intervalsString)) { this.removeHighlightFragments(); return; }
+    if (Boolean(intervalsString)) {
 
     const intervals = intervalsString.split(",").filter(Boolean).map(ns => {
       const [start, end] = ns.split("-").map(s => parseInt(s));
       return { start, end };
     });
 
-    this.removeHighlightFragments();
+      this._removeHighlightFragments();
 
-    this._highlightFragments = intervals.map(({ start, end }) => {
+      this._highlightedFragments = intervals.map(({ start, end }) => {
       const width = Math.max(1, this._x(end) - this._x(start));
       return this._fragmentsGroup
         .append("rect")
@@ -202,6 +203,7 @@ class ProtvistaPdbNavigation extends ProtvistaNavigation {
         .attr("height", height)
         .attr("width", width);
     });
+    } else this._removeHighlightFragments();
   }
 
   _updateObserveHighlight() {

--- a/src/custom-pv-components/pdb-sequence.js
+++ b/src/custom-pv-components/pdb-sequence.js
@@ -6,7 +6,7 @@ const height = 40;
 class ProtvistaPdbSequence extends ProtvistaSequence {
   connectedCallback() {
     super.connectedCallback();
-    this._highlightintervals = parseInt(this.getAttribute("highlightintervals"));
+    this._highlightintervals = this.getAttribute("highlightintervals");
   }
 
   static get observedAttributes() {
@@ -39,7 +39,7 @@ class ProtvistaPdbSequence extends ProtvistaSequence {
 
   refresh() {
     super.refresh();
-    if (this.axis) {
+    if (this._fragmentsGroup) {
       const intervalsString = (this._highlightintervals || "").split(":")[1] || "";
       if (Boolean(intervalsString)) {
         const intervals = intervalsString.split(",").filter(Boolean).map(ns => {

--- a/src/custom-pv-components/pdb-sequence.js
+++ b/src/custom-pv-components/pdb-sequence.js
@@ -1,0 +1,67 @@
+import { select } from 'd3';
+import ProtvistaSequence from "protvista-sequence";
+
+const height = 40;
+
+class ProtvistaPdbSequence extends ProtvistaSequence {
+  connectedCallback() {
+    super.connectedCallback();
+    this._highlightintervals = parseInt(this.getAttribute("highlightintervals"));
+  }
+
+  static get observedAttributes() {
+    return super.observedAttributes.concat("highlightintervals");
+  }
+
+  _createSequence() {
+    super.svg = select(this)
+      .append("div").attr("class", "")
+      .append("svg").attr("id", "").attr("width", this.width).attr("height", height);
+
+    this.seq_bg = super.svg.append("g").attr("class", "background");
+    this.axis = super.svg.append("g").attr("class", "x axis");
+    this.seq_g = super.svg.append("g").attr("class", "sequence").attr("transform", `translate(0,${0.75 * height})`);
+
+    this.seq_g.append("text").attr("class", "base").text("T");
+    this.chWidth = this.seq_g.select("text.base").node().getBBox().width * 0.8;
+    this.seq_g.select("text.base").remove();
+
+    this.highlighted = super.svg.append("rect").attr("class", "highlighted").attr("fill", "yellow").attr("height", height);
+    this._fragmentsGroup = this._svg.append("g");
+
+    this.refresh();
+  }
+
+  removeHighlightFragments() {
+    if (this._highlightFragments && this._highlightFragments.length > 0)
+      this._highlightFragments.forEach(rect => rect.remove());
+  }
+
+  refresh() {
+    super.refresh();
+    if (this.axis) {
+      const intervalsString = (this._highlightintervals || "").split(":")[1] || "";
+      if (Boolean(intervalsString)) {
+        const intervals = intervalsString.split(",").filter(Boolean).map(ns => {
+          const [start, end] = ns.split("-").map(s => parseInt(s));
+          return { start, end };
+        });
+
+        this.removeHighlightFragments();
+
+        this._highlightFragments = intervals.map(({ start, end }) => {
+          return this._fragmentsGroup
+            .append("rect")
+            .attr("fill", "rgba(255, 145, 0, 0.8)")
+            .attr("opacity", 0.4)
+            .attr("x", super.getXFromSeqPosition(start))
+            .attr("y", 0)
+            .attr("height", height)
+            .attr("width", this.getSingleBaseWidth() * (end - start + 1));
+        });
+      } else this.removeHighlightFragments();
+    }
+  }
+}
+
+export default ProtvistaPdbSequence;

--- a/src/custom-pv-components/pdb-sequence.js
+++ b/src/custom-pv-components/pdb-sequence.js
@@ -7,6 +7,8 @@ class ProtvistaPdbSequence extends ProtvistaSequence {
   connectedCallback() {
     super.connectedCallback();
     this._highlightintervals = this.getAttribute("highlightintervals");
+
+    this._highlightedFragments = [];
   }
 
   static get observedAttributes() {
@@ -32,9 +34,9 @@ class ProtvistaPdbSequence extends ProtvistaSequence {
     this.refresh();
   }
 
-  removeHighlightFragments() {
-    if (this._highlightFragments && this._highlightFragments.length > 0)
-      this._highlightFragments.forEach(rect => rect.remove());
+  _removeHighlightFragments() {
+    if (this._highlightedFragments && this._highlightedFragments.length > 0)
+      this._highlightedFragments.forEach(rect => rect.remove());
   }
 
   refresh() {
@@ -47,9 +49,9 @@ class ProtvistaPdbSequence extends ProtvistaSequence {
           return { start, end };
         });
 
-        this.removeHighlightFragments();
+        this._removeHighlightFragments();
 
-        this._highlightFragments = intervals.map(({ start, end }) => {
+        this._highlightedFragments = intervals.map(({ start, end }) => {
           return this._fragmentsGroup
             .append("rect")
             .attr("fill", "rgba(255, 145, 0, 0.8)")
@@ -59,7 +61,7 @@ class ProtvistaPdbSequence extends ProtvistaSequence {
             .attr("height", height)
             .attr("width", this.getSingleBaseWidth() * (end - start + 1));
         });
-      } else this.removeHighlightFragments();
+      } else this._removeHighlightFragments();
     }
   }
 }

--- a/src/custom-pv-components/pdb-tooltip.js
+++ b/src/custom-pv-components/pdb-tooltip.js
@@ -111,7 +111,7 @@ class ProtvistaPdbTooltip extends HTMLElement {
 
         let html = `<div class="tooltip-header"><span class="tooltip-header-title">${this._title}</span>`;
         if(this.closeable) {
-            html = `${html}<span class="tooltip-close" style="float:right"></span>`
+            html = `${html}<span class="tooltip-close"></span>`
         }
         html = `${html}</div><div class="tooltip-body">${this._content}</div>`;
         this.innerHTML = html;

--- a/src/custom-pv-components/pdb-track.js
+++ b/src/custom-pv-components/pdb-track.js
@@ -160,7 +160,7 @@ class ProtvistaPdbTrack extends ProtvistaTrack {
           })
         );
         this.dispatchEvent(
-          new CustomEvent("protvista-highlight", {
+          new CustomEvent("protvista-highlight-interval", {
             detail: f,
             bubbles: true,
             cancelable: true
@@ -259,6 +259,15 @@ class ProtvistaPdbTrack extends ProtvistaTrack {
         ));
         this.dispatchEvent(
           new CustomEvent("protvista-remove-highlight", {
+            bubbles: true,
+            cancelable: true
+          })
+        );
+
+        //Add new highlight
+        this.dispatchEvent(
+          new CustomEvent("protvista-highlight-fragments", {
+            detail: { intervalsString: this._highlightintervals },
             bubbles: true,
             cancelable: true
           })

--- a/src/custom-pv-components/pdb-track.js
+++ b/src/custom-pv-components/pdb-track.js
@@ -117,7 +117,7 @@ class ProtvistaPdbTrack extends ProtvistaTrack {
         let lightColor = this.colorMixer(-0.3, apiColor); //lightened by 30%
         return lightColor;
       })
-      .on("mouseover", (f, i) => {
+      .on("mouseenter", (f, i) => {
         const self = this;
         const e = d3.event;
   
@@ -257,6 +257,12 @@ class ProtvistaPdbTrack extends ProtvistaTrack {
             cancelable: true
           })
         ));
+        this.dispatchEvent(
+          new CustomEvent("protvista-remove-highlight", {
+            bubbles: true,
+            cancelable: true
+          })
+        );
       });
   }
 

--- a/src/custom-pv-components/pdb-track.js
+++ b/src/custom-pv-components/pdb-track.js
@@ -292,8 +292,9 @@ class ProtvistaPdbTrack extends ProtvistaTrack {
     this.removeAllTooltips();
     const tooltip = document.createElement("protvista-tooltip");
     
-    tooltip.left =  e.pageX + 15; 
-    tooltip.top = e.pageY + 5;
+    tooltip.left = e.pageX + 12;
+    tooltip.top = e.pageY + 12;
+    tooltip.style.marginRight = 32 + 'px';
     tooltip.style.marginLeft = 0;
     tooltip.style.marginTop = 0;
     
@@ -311,15 +312,15 @@ class ProtvistaPdbTrack extends ProtvistaTrack {
     const toolTipEl = d3.select(tooltip).node();
     const tooltipDom = toolTipEl.getBoundingClientRect();
     const bottomSpace = window.innerHeight - e.clientY;
-    const rightSpace = window.innerWidth - e.clientX;
+    const rightSpace = document.documentElement.clientWidth - e.clientX; //not window.innerWidth in order to remove possible scrollbars
     
-    if(bottomSpace < 130){
-      toolTipEl.style.top = e.pageY - (tooltipDom.height + 20) +'px';
+    if (bottomSpace < tooltipDom.height) {
+      toolTipEl.style.top = e.pageY - (tooltipDom.height + 8) + 'px';
     }
 
-    if(rightSpace < 300){
+    if (rightSpace < tooltipDom.width) {
       toolTipEl.style.left = '';
-      toolTipEl.style.right = (rightSpace - 10)+'px';
+      toolTipEl.style.right = (rightSpace - 12) + 'px';
     }
   }
 

--- a/src/custom-pv-components/pdb-track.js
+++ b/src/custom-pv-components/pdb-track.js
@@ -148,6 +148,13 @@ class ProtvistaPdbTrack extends ProtvistaTrack {
             cancelable: true
           })
         );
+        this.dispatchEvent(
+          new CustomEvent("protvista-highlight", {
+            detail: f,
+            bubbles: true,
+            cancelable: true
+          })
+        );
       })
       .on("mouseout", () => {
         const self = this;
@@ -272,7 +279,7 @@ class ProtvistaPdbTrack extends ProtvistaTrack {
     if(h)return"rgb"+(f?"a(":"(")+r+","+g+","+b+(f?","+m(a*1000)/1000:"")+")";
     else return"#"+(4294967296+r*16777216+g*65536+b*256+(f?m(a*255):0)).toString(16).slice(1,f?undefined:-2)
   }
-  
+
   _updateHighlight() {
     super._updateHighlight();
 

--- a/src/custom-pv-components/pdb-track.js
+++ b/src/custom-pv-components/pdb-track.js
@@ -180,13 +180,6 @@ class ProtvistaPdbTrack extends ProtvistaTrack {
             cancelable: true
           })
         );
-        this.dispatchEvent(
-          new CustomEvent("protvista-highlight-interval", {
-            detail: f,
-            bubbles: true,
-            cancelable: true
-          })
-        );
       })
       .on("mouseout", () => {
         const self = this;
@@ -219,13 +212,6 @@ class ProtvistaPdbTrack extends ProtvistaTrack {
         this.dispatchEvent(
           new CustomEvent("protvista-mouseout", {
             detail: null,
-            bubbles: true,
-            cancelable: true
-          })
-        );
-
-        this.dispatchEvent(
-          new CustomEvent("protvista-remove-highlight", {
             bubbles: true,
             cancelable: true
           })
@@ -280,21 +266,6 @@ class ProtvistaPdbTrack extends ProtvistaTrack {
             cancelable: true
           })
         ));
-        this.dispatchEvent(
-          new CustomEvent("protvista-remove-highlight", {
-            bubbles: true,
-            cancelable: true
-          })
-        );
-
-        //Add new highlight
-        this.dispatchEvent(
-          new CustomEvent("protvista-highlight-fragments", {
-            detail: { intervalsString: this._highlightintervals },
-            bubbles: true,
-            cancelable: true
-          })
-        );
       });
   }
 

--- a/src/custom-pv-components/pdb-track.js
+++ b/src/custom-pv-components/pdb-track.js
@@ -202,6 +202,13 @@ class ProtvistaPdbTrack extends ProtvistaTrack {
             cancelable: true
           })
         );
+
+        this.dispatchEvent(
+          new CustomEvent("protvista-remove-highlight", {
+            bubbles: true,
+            cancelable: true
+          })
+        );
       })
       .on("click", (d, i) => {
         d.trackIndex = i;
@@ -220,6 +227,36 @@ class ProtvistaPdbTrack extends ProtvistaTrack {
             cancelable: true
           })
         );
+
+        this.dispatchEvent(
+          new CustomEvent("protvista-highlight-selection", {
+            detail: {
+              fragment: {
+                start: d.start,
+                end: d.end,
+              }
+            },
+            bubbles: true,
+            cancelable: true
+          })
+        );
+
+        //Remove previous highlight
+        const protvistaPdbs = document.querySelectorAll("protvista-pdb");
+        const pdbFirstTracks = Array.from(protvistaPdbs)
+          .map(el => el.querySelector("protvista-pdb-track"))
+          .filter(Boolean);
+
+        pdbFirstTracks.forEach(el => el.dispatchEvent(
+          new CustomEvent("change", {
+            detail: {
+              highlightend: null,
+              highlightstart: null
+            },
+            bubbles: true,
+            cancelable: true
+          })
+        ));
       });
   }
 
@@ -320,7 +357,7 @@ class ProtvistaPdbTrack extends ProtvistaTrack {
       .append("rect")
       .merge(selection)
       .attr("class", "hi")
-      .attr("fill", "rgba(255, 235, 59, 0.8)")
+      .attr("fill", "rgba(255, 145, 0, 0.8)")
       .attr('stroke', 'black')
       .attr("height", this._height)
       .attr("x", interval => this.getXFromSeqPosition(interval.start))

--- a/src/custom-pv-components/pdb-track.js
+++ b/src/custom-pv-components/pdb-track.js
@@ -130,7 +130,17 @@ class ProtvistaPdbTrack extends ProtvistaTrack {
           }, 50);
         }
         
-        this.dispatchEvent(
+        const protvistaPdbs = document.querySelectorAll("protvista-pdb");
+        const pdbFirstTracks = Array.from(protvistaPdbs)
+          .map(el => el.querySelector("protvista-pdb-track"))
+          .filter(Boolean);
+
+        /* This is not the best way to perform this. The event "change"
+        already comes from protvista, that listen (`addListeners`) and updates
+        each element (`this.protvistaElements` from ProtVistaManager) attributes.
+        So in order to update all tracks, we need to fire each event on some track of
+        each protvista-pdb instance. Also on 'mouseout'. */
+        pdbFirstTracks.forEach(el => el.dispatchEvent(
           new CustomEvent("change", {
             detail: {
               highlightend: f.end,
@@ -139,7 +149,8 @@ class ProtvistaPdbTrack extends ProtvistaTrack {
             bubbles: true,
             cancelable: true
           })
-        );
+        ));
+
         f.trackIndex = i;
         this.dispatchEvent(
           new CustomEvent("protvista-mouseover", {
@@ -168,7 +179,12 @@ class ProtvistaPdbTrack extends ProtvistaTrack {
           }, 50);
         }
 
-        this.dispatchEvent(
+        const protvistaPdbs = document.querySelectorAll("protvista-pdb");
+        const pdbFirstTracks = Array.from(protvistaPdbs)
+          .map(el => el.querySelector("protvista-pdb-track"))
+          .filter(Boolean);
+
+        pdbFirstTracks.forEach(el => el.dispatchEvent(
           new CustomEvent("change", {
             detail: {
               highlightend: null,
@@ -177,7 +193,8 @@ class ProtvistaPdbTrack extends ProtvistaTrack {
             bubbles: true,
             cancelable: true
           })
-        );
+        ));
+
         this.dispatchEvent(
           new CustomEvent("protvista-mouseout", {
             detail: null,

--- a/src/custom-pv-components/pdb-track.js
+++ b/src/custom-pv-components/pdb-track.js
@@ -234,6 +234,8 @@ class ProtvistaPdbTrack extends ProtvistaTrack {
               fragment: {
                 start: d.start,
                 end: d.end,
+                color: d.color,
+                feature: d.feature
               }
             },
             bubbles: true,

--- a/src/helpers/layout.js
+++ b/src/helpers/layout.js
@@ -372,16 +372,6 @@ class LayoutHelper {
             }, bubbles: true, cancelable: true
             }));
 
-            navEle.dispatchEvent(
-                new CustomEvent("protvista-highlight-interval", {
-                    detail: {
-                        start: currentStartVal,
-                        end: currentEndVal,
-                    },
-                    bubbles: true,
-                    cancelable: true
-                })
-            );
 
         } else {
 

--- a/src/helpers/layout.js
+++ b/src/helpers/layout.js
@@ -678,9 +678,17 @@ class LayoutHelper {
                     endVal = this.ctx.viewerData.length;
                 }
 
-                let resetParam = { start: Math.round(startVal), end: Math.round(endVal), highlight: true }
+                const fragment = { start: Math.round(startVal), end: Math.round(endVal), feature: { bestChainId: this.ctx.chainId } }
 
-                this.resetZoom(resetParam);
+                document.dispatchEvent(
+                    new CustomEvent("protvista-click", {
+                        detail: fragment,
+                        bubbles: true,
+                        cancelable: true
+                    })
+                );
+
+                this.ctx.setSubtrackFragmentsSelection({ isEnabled: true, fragment });
                 this.openHighlightRangeMenu();
             }
         }

--- a/src/helpers/layout.js
+++ b/src/helpers/layout.js
@@ -373,7 +373,7 @@ class LayoutHelper {
             }));
 
             navEle.dispatchEvent(
-                new CustomEvent("protvista-highlight", {
+                new CustomEvent("protvista-highlight-interval", {
                     detail: {
                         start: currentStartVal,
                         end: currentEndVal,

--- a/src/helpers/layout.js
+++ b/src/helpers/layout.js
@@ -512,7 +512,7 @@ class LayoutHelper {
         this.ctx.hiddenSections = [];
         this.ctx.hiddenSubtracks = Object.assign({},{});
           
-        
+        this.ctx.setSubtrackFragmentsSelection({ isEnabled: false });
     }
 
     toggleTooltip(className, top, callback) {

--- a/src/helpers/layout.js
+++ b/src/helpers/layout.js
@@ -523,8 +523,10 @@ class LayoutHelper {
             menu.style.top = (actionSource.y + top) + 'px';
             menu.style.display = 'block';
             if (callback) callback(menu, this.ctx);
+            return { state: "visible" };
         } else {
             menu.style.display = 'none';
+            return { state: "hidden" };
         }
     }
 
@@ -554,7 +556,7 @@ class LayoutHelper {
             }
         }
 
-        this.toggleTooltip(".viewRangeMenu", 16, rangeMenu);
+        this.toggleTooltip(".viewRangeMenu", -16, rangeMenu);
     }
 
     openHighlightRangeMenu() {
@@ -583,10 +585,14 @@ class LayoutHelper {
             }
         }
 
-        this.toggleTooltip(".highlightRangeMenu", 16, rangeMenu);
+        this.toggleTooltip(".highlightRangeMenu", -16, rangeMenu);
     }
 
     openMoreOptions(trackIndex, subtrackIndex) {
+        //Check if already visible
+        const { state } = this.toggleTooltip(`.moreOptionsMenu_${trackIndex}_${subtrackIndex}`, -16);
+        //If is hidden is because it was already visible and got hidden
+        if (state === "hidden") { this.hideMoreOptions(); this.hideInfoTooltips(); return; }
         //Close other open menus
         this.ctx.querySelector('.settingsMenu').style.display = 'none';
         this.ctx.querySelector('.viewRangeMenu').style.display = 'none';
@@ -637,7 +643,7 @@ class LayoutHelper {
             });
         }
 
-        this.toggleTooltip(".settingsMenu", 16, settingsMenu);
+        this.toggleTooltip(".settingsMenu", -16, settingsMenu);
     }
 
     pvViewRangeMenuSubmit() {

--- a/src/helpers/layout.js
+++ b/src/helpers/layout.js
@@ -433,7 +433,8 @@ class LayoutHelper {
 
         //Close open menus
         this.ctx.querySelector('.settingsMenu').style.display = 'none';
-        this.ctx.querySelector('.rangeMenu').style.display = 'none';
+        this.ctx.querySelector('.viewRangeMenu').style.display = 'none';
+        this.ctx.querySelector('.highlightRangeMenu').style.display = 'none';
         this.hideMoreOptions();
         this.hideInfoTooltips();
 
@@ -514,7 +515,7 @@ class LayoutHelper {
         
     }
 
-    openTooltip(className, top, callback) {
+    toggleTooltip(className, top, callback) {
         const menu = this.ctx.querySelector(className);
         if (menu.style.display == 'none') {
             const actionSource = menu.previousElementSibling.getBoundingClientRect();
@@ -527,15 +528,16 @@ class LayoutHelper {
         }
     }
 
-    openRangeMenu() {
+    openViewRangeMenu() {
         //Close other open menus
         this.ctx.querySelector('.settingsMenu').style.display = 'none';
+        this.ctx.querySelector('.highlightRangeMenu').style.display = 'none';
         this.hideMoreOptions();
         this.hideInfoTooltips();
 
         function rangeMenu(_menu, ctx) {
-            let startEle = ctx.querySelector('.pvRangeMenuStart');
-            let endEle = ctx.querySelector('.pvRangeMenuEnd');
+            let startEle = ctx.querySelector('.pvViewRangeMenuStart');
+            let endEle = ctx.querySelector('.pvViewRangeMenuEnd');
 
             if (startEle.value == 0 || endEle.value == 0) {
                 let currentStartVal = 1;
@@ -552,22 +554,53 @@ class LayoutHelper {
             }
         }
 
-        this.openTooltip(".rangeMenu", 16, rangeMenu);
+        this.toggleTooltip(".viewRangeMenu", 16, rangeMenu);
+    }
+
+    openHighlightRangeMenu() {
+        //Close other open menus
+        this.ctx.querySelector('.settingsMenu').style.display = 'none';
+        this.ctx.querySelector('.viewRangeMenu').style.display = 'none';
+        this.hideMoreOptions();
+        this.hideInfoTooltips();
+
+        function rangeMenu(_menu, ctx) {
+            let startEle = ctx.querySelector('.pvHighlightRangeMenuStart');
+            let endEle = ctx.querySelector('.pvHighlightRangeMenuEnd');
+
+            if (startEle.value == 0 || endEle.value == 0) {
+                let currentStartVal = 1;
+                let currentEndVal = ctx.viewerData.length;
+
+                let navEle = ctx.querySelectorAll('.pvTrack')[0];
+                if (navEle) {
+                    currentStartVal = navEle.getAttribute('displaystart');
+                    currentEndVal = navEle.getAttribute('displayend');
+                }
+
+                startEle.value = Math.round(currentStartVal);
+                endEle.value = Math.round(currentEndVal);
+            }
+        }
+
+        this.toggleTooltip(".highlightRangeMenu", 16, rangeMenu);
     }
 
     openMoreOptions(trackIndex, subtrackIndex) {
         //Close other open menus
         this.ctx.querySelector('.settingsMenu').style.display = 'none';
-        this.ctx.querySelector('.rangeMenu').style.display = 'none';
+        this.ctx.querySelector('.viewRangeMenu').style.display = 'none';
+        this.ctx.querySelector('.highlightRangeMenu').style.display = 'none';
         this.hideInfoTooltips();
         this.hideMoreOptions();
-        this.openTooltip(`.moreOptionsMenu_${trackIndex}_${subtrackIndex}`, -16);
+        this.toggleTooltip(`.moreOptionsMenu_${trackIndex}_${subtrackIndex}`, -16);
     }
 
     showInfoTooltip(trackIndex, subtrackIndex) {
         //Close other open menus
         this.ctx.querySelector('.settingsMenu').style.display = 'none';
-        this.ctx.querySelector('.rangeMenu').style.display = 'none';
+        this.ctx.querySelector('.viewRangeMenu').style.display = 'none';
+        this.ctx.querySelector('.highlightRangeMenu').style.display = 'none';
         this.hideInfoTooltips();
 
         const tooltipBox = this.ctx.querySelector(`.infoTooltip_${trackIndex}_${subtrackIndex}`);
@@ -593,7 +626,8 @@ class LayoutHelper {
     openCategorySettingsMenu(){
 
         //Close other open menus
-        this.ctx.querySelector('.rangeMenu').style.display = 'none';
+        this.ctx.querySelector('.viewRangeMenu').style.display = 'none';
+        this.ctx.querySelector('.highlightRangeMenu').style.display = 'none';
         this.hideMoreOptions();
         this.hideInfoTooltips();
 
@@ -603,12 +637,12 @@ class LayoutHelper {
             });
         }
 
-        this.openTooltip(".settingsMenu", 16, settingsMenu);
+        this.toggleTooltip(".settingsMenu", 16, settingsMenu);
     }
 
-    pvRangeMenuSubmit(){
-        let startVal = this.ctx.querySelector('.pvRangeMenuStart').value;
-        let endVal = this.ctx.querySelector('.pvRangeMenuEnd').value;
+    pvViewRangeMenuSubmit() {
+        let startVal = this.ctx.querySelector('.pvViewRangeMenuStart').value;
+        let endVal = this.ctx.querySelector('.pvViewRangeMenuEnd').value;
 
         if(startVal != '' && endVal != ''){
             startVal = parseFloat(startVal);
@@ -618,15 +652,30 @@ class LayoutHelper {
                     endVal = this.ctx.viewerData.length;
                 }
 
-                let resetParam = {start: Math.round(startVal), end: Math.round(endVal)}
-
-                let highlightCheckEle = this.ctx.querySelector('.pvRangeMenuHighlight');
-                if(highlightCheckEle.checked){
-                    resetParam['highlight'] = true;
-                }
+                let resetParam = { start: Math.round(startVal), end: Math.round(endVal), highlight: false }
 
                 this.resetZoom(resetParam);
-                this.openRangeMenu();
+                this.openViewRangeMenu();
+            }
+        }
+    }
+
+    pvHighlightRangeMenuSubmit() {
+        let startVal = this.ctx.querySelector('.pvHighlightRangeMenuStart').value;
+        let endVal = this.ctx.querySelector('.pvHighlightRangeMenuEnd').value;
+
+        if (startVal != '' && endVal != '') {
+            startVal = parseFloat(startVal);
+            endVal = parseFloat(endVal);
+            if (endVal >= startVal) {
+                if (endVal > this.ctx.viewerData.length) {
+                    endVal = this.ctx.viewerData.length;
+                }
+
+                let resetParam = { start: Math.round(startVal), end: Math.round(endVal), highlight: true }
+
+                this.resetZoom(resetParam);
+                this.openHighlightRangeMenu();
             }
         }
     }

--- a/src/helpers/layout.js
+++ b/src/helpers/layout.js
@@ -365,22 +365,33 @@ class LayoutHelper {
         }
     
         if(typeof param !== 'undefined' && typeof param.highlight !== 'undefined' && param.highlight){
-          navEle.dispatchEvent(new CustomEvent('change', {
+            navEle.dispatchEvent(new CustomEvent('change', {
             detail: {
-              highlightstart: currentStartVal,
-              highlightend: currentEndVal
+                    highlightstart: currentStartVal,
+                    highlightend: currentEndVal
             }, bubbles: true, cancelable: true
-          }));
-          
-        }else{
+            }));
+
+            navEle.dispatchEvent(
+                new CustomEvent("protvista-highlight", {
+                    detail: {
+                        start: currentStartVal,
+                        end: currentEndVal,
+                    },
+                    bubbles: true,
+                    cancelable: true
+                })
+            );
+
+        } else {
 
             navEle.dispatchEvent(new CustomEvent('change', {
                 detail: {
-                  displaystart: currentStartVal,
-                  displayend: currentEndVal
+                    displaystart: currentStartVal,
+                    displayend: currentEndVal
                 }, bubbles: true, cancelable: true
-            }));  
-    
+            }));
+
           navEle.dispatchEvent(new CustomEvent('change', {
             detail: {
               highlightstart: null,

--- a/src/helpers/layout.js
+++ b/src/helpers/layout.js
@@ -25,7 +25,7 @@ class LayoutHelper {
             seqSectionEle.style.paddingRight = this.ctx.scrollbarWidth+'px';
             setTimeout(() => {
                 let seqEle = this.ctx.querySelectorAll('protvista-sequence')[0];
-                if(seqEle) seqEle.firstElementChild.firstElementChild.style.width = '100%';
+                if (seqEle && seqEle.firstElementChild && seqEle.firstElementChild.firstElementChild) seqEle.firstElementChild.firstElementChild.style.width = '100%';
             },100);
         }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
 // original PV components
 import ProtvistaManager from "protvista-manager";
-import ProtvistaSequence from "protvista-sequence";
 import ProtvistaFilter from "protvista-filter";
 
 // customised PV components
+import ProtvistaPdbSequence from "./custom-pv-components/pdb-sequence";
 import ProtvistaPdbNavigation from "./custom-pv-components/pdb-navigation";
 import ProtvistaPdbTrack from './custom-pv-components/pdb-track'
 import ProtvistaPdbScHistogram from './custom-pv-components/pdb-sc-histogram'
@@ -16,8 +16,8 @@ import { loadComponent } from "./loadComponent";
 
 const registerWebComponents = function() {
     loadComponent("protvista-manager", ProtvistaManager);
-    loadComponent("protvista-sequence", ProtvistaSequence);
     loadComponent("protvista-filter", ProtvistaFilter);
+    loadComponent("protvista-pdb-sequence", ProtvistaPdbSequence);
     loadComponent("protvista-pdb-navigation", ProtvistaPdbNavigation);
     loadComponent("protvista-pdb-track", ProtvistaPdbTrack);
     loadComponent("protvista-pdb-sc-histogram", ProtvistaPdbScHistogram);

--- a/src/protvista-pdb.js
+++ b/src/protvista-pdb.js
@@ -171,8 +171,6 @@ class ProtvistaPDB extends HTMLElement {
 
     setSubtrackFragmentsSelection(options) {
 
-        //Remove highlight fragments
-        if (!options.isEnabled) sendEvent(window, "protvista-remove-fragments", undefined);
         this.highlightActive = options.isEnabled;
 
         const trackEl = this.querySelector("protvista-pdb-track");
@@ -222,8 +220,6 @@ class ProtvistaPDB extends HTMLElement {
         sendEvent(trackEl, "change", { highlightintervals });
         sendEvents(otherProtvistaPdbs, "change", { highlightintervals });
         sendEvent(trackEl, "protvista-multiselect", { fragments });
-        if (!options.fragment && options.isEnabled && highlightintervals !== null)
-            sendEvent(window, "protvista-highlight-fragments", { intervalsString: highlightintervals })
     }
 }
 

--- a/src/protvista-pdb.js
+++ b/src/protvista-pdb.js
@@ -173,53 +173,52 @@ class ProtvistaPDB extends HTMLElement {
 
         this.highlightActive = options.isEnabled;
 
-        const trackEl = this.querySelector("protvista-pdb-track");
-        const protvistaPdbs = document.querySelectorAll("protvista-pdb");
-        const otherProtvistaPdbs = Array.from(protvistaPdbs)
-            .filter(el => el !== this)
+        const protvistaPdbs = Array.from(document.querySelectorAll("protvista-pdb"))
             .map(el => el.querySelector("protvista-pdb-track"))
             .filter(Boolean);
 
-        const changeIcon = (el, enabled) => {
-            if (!el.classList.contains("protvistaToolbarIcon")) {
+        const changeIcon = (el, enabled, options) => {
+            if (options.activateButton) {
                 if (enabled) el.classList.add("enabled");
                 else el.classList.remove("enabled");
             }
-            const icon = el.children[0];
-            const text = el.children[1];
-            if (icon && text) {
-                icon.classList.remove(enabled ? "icon-star" : "icon-undo-alt");
-                icon.classList.add(enabled ? "icon-undo-alt" : "icon-star");
-                text.innerText = enabled ? "Undo highlight" : "Highlight fragments";
-            } else if (icon && el.classList.contains("protvistaToolbarIcon")) {
-                icon.classList.remove(enabled ? "icon-star" : "icon-undo-alt");
-                icon.classList.add(enabled ? "icon-undo-alt" : "icon-star");
-                el.title = enabled ? "Undo highlight" : "Highlight region";
+
+            const iconEl = el.children[0];
+            const textEl = el.children[1];
+            const text = enabled ? options.text.enabled : options.text.disabled;
+
+            if (iconEl) {
+                iconEl.classList.remove(enabled ? "icon-star" : "icon-undo-alt");
+                iconEl.classList.add(enabled ? "icon-undo-alt" : "icon-star");
+            }
+
+            if (textEl) {
+                textEl.innerText = text;
+            } else {
+                el.title = text;
             }
         }
 
         document.querySelectorAll(".labelHighlightRight, .highlightToolbarIcon").forEach(el => {
             //in order to change the icon in all protvista-pdb instances
-            changeIcon(el, options.isEnabled);
+            changeIcon(el, options.isEnabled, {
+                activateButton: !el.classList.contains("protvistaToolbarIcon"),
+                text: {
+                    enabled: "Undo highlight",
+                    disabled: el.classList.contains("protvistaToolbarIcon") ? "Highlight region" : "Highlight fragments"
+                }
+            });
         });
 
-        let fragments;
-
-        if (options.isEnabled && options.fragment) {
-            fragments = [options.fragment];
-        } else if (options.isEnabled) {
-            const { subtrackData } = options;
-            const locFragments = flatten(subtrackData.locations.map(location => location.fragments));
-            fragments = locFragments.map(fragment => ({ ...fragment, feature: subtrackData }));
-        } else {
-            fragments = [];
-        }
+        const { subtrackData } = options;
+        const locFragments = options.isEnabled && subtrackData ? flatten(subtrackData.locations.map(location => location.fragments)).map(fragment => ({ ...fragment, feature: subtrackData })) : [];
+        const fragments = options.isEnabled && options.fragment ? [options.fragment] : locFragments;
 
         const intervals = fragments.map(fragment => [fragment.start, fragment.end].join("-"));
         const highlightintervals = intervals.length > 0 ? `:${intervals.join(",")}` : null;
-        sendEvent(trackEl, "change", { highlightintervals });
-        sendEvents(otherProtvistaPdbs, "change", { highlightintervals });
-        sendEvent(trackEl, "protvista-multiselect", { fragments });
+
+        sendEvents(protvistaPdbs, "change", { highlightintervals });
+        sendEvent(document, "protvista-multiselect", { fragments });
     }
 }
 

--- a/src/protvista-pdb.js
+++ b/src/protvista-pdb.js
@@ -44,6 +44,8 @@ class ProtvistaPDB extends HTMLElement {
         this.addEventListener("protvista-highlight-selection", e => {
             this.setSubtrackFragmentsSelection({ isEnabled: true, fragment: e.detail.fragment });
         });
+
+        this.highlightActive = false;
     }
 
     set viewerdata(data) {
@@ -169,6 +171,7 @@ class ProtvistaPDB extends HTMLElement {
 
         //Remove highlight fragments
         if (!options.isEnabled) sendEvent(window, "protvista-remove-fragments", undefined);
+        this.highlightActive = options.isEnabled;
 
         const trackEl = this.querySelector("protvista-pdb-track");
         const protvistaPdbs = document.querySelectorAll("protvista-pdb");
@@ -178,18 +181,24 @@ class ProtvistaPDB extends HTMLElement {
             .filter(Boolean);
 
         const changeIcon = (el, enabled) => {
-            if (enabled) el.classList.add("enabled");
-            else el.classList.remove("enabled");
+            if (!el.classList.contains("protvistaToolbarIcon")) {
+                if (enabled) el.classList.add("enabled");
+                else el.classList.remove("enabled");
+            }
             const icon = el.children[0];
             const text = el.children[1];
             if (icon && text) {
                 icon.classList.remove(enabled ? "icon-star" : "icon-undo-alt");
                 icon.classList.add(enabled ? "icon-undo-alt" : "icon-star");
                 text.innerText = enabled ? "Undo highlight" : "Highlight fragments";
+            } else if (icon && el.classList.contains("protvistaToolbarIcon")) {
+                icon.classList.remove(enabled ? "icon-star" : "icon-undo-alt");
+                icon.classList.add(enabled ? "icon-undo-alt" : "icon-star");
+                el.title = enabled ? "Undo highlight" : "Highlight region";
             }
         }
 
-        document.querySelectorAll(".labelHighlightRight").forEach(el => {
+        document.querySelectorAll(".labelHighlightRight, .highlightToolbarIcon").forEach(el => {
             //in order to change the icon in all protvista-pdb instances
             changeIcon(el, options.isEnabled);
         });

--- a/src/protvista-pdb.js
+++ b/src/protvista-pdb.js
@@ -166,6 +166,10 @@ class ProtvistaPDB extends HTMLElement {
     }
 
     setSubtrackFragmentsSelection(options) {
+
+        //Remove highlight fragments
+        if (!options.isEnabled) sendEvent(window, "protvista-remove-fragments", undefined);
+
         const trackEl = this.querySelector("protvista-pdb-track");
         const protvistaPdbs = document.querySelectorAll("protvista-pdb");
         const otherProtvistaPdbs = Array.from(protvistaPdbs)
@@ -207,6 +211,8 @@ class ProtvistaPDB extends HTMLElement {
         sendEvent(trackEl, "change", { highlightintervals });
         sendEvents(otherProtvistaPdbs, "change", { highlightintervals });
         sendEvent(trackEl, "protvista-multiselect", { fragments });
+        if (!options.fragment && options.isEnabled && highlightintervals !== null)
+            sendEvent(window, "protvista-highlight-fragments", { intervalsString: highlightintervals })
     }
 }
 

--- a/src/protvista-pdb.js
+++ b/src/protvista-pdb.js
@@ -65,6 +65,8 @@ class ProtvistaPDB extends HTMLElement {
                 this.variantFilterAttr = JSON.stringify(this.viewerData.variants.filters);
         }
 
+        this.chainId = this.viewerData.chainId;
+
         this._render();
     }
 

--- a/src/protvista-pdb.js
+++ b/src/protvista-pdb.js
@@ -40,6 +40,10 @@ class ProtvistaPDB extends HTMLElement {
         this.addEventListener("protvista-unselect", e => {
             this.setSubtrackFragmentsSelection({ isEnabled: false });
         });
+
+        this.addEventListener("protvista-highlight-selection", e => {
+            this.setSubtrackFragmentsSelection({ isEnabled: true, fragment: e.detail.fragment });
+        });
     }
 
     set viewerdata(data) {
@@ -182,16 +186,17 @@ class ProtvistaPDB extends HTMLElement {
         }
 
         document.querySelectorAll(".labelHighlightRight").forEach(el => {
-            changeIcon(el, false);
+            //in order to change the icon in all protvista-pdb instances
+            changeIcon(el, options.isEnabled);
         });
 
         let fragments;
 
-        if (options.isEnabled) {
-            const { trackIndex, subtrackIndex, subtrackData } = options;
-            const buttonEl = this.querySelector(`.pvHighlight_${trackIndex}_${subtrackIndex}`);
+        if (options.isEnabled && options.fragment) {
+            fragments = [options.fragment];
+        } else if (options.isEnabled) {
+            const { subtrackData } = options;
             const locFragments = flatten(subtrackData.locations.map(location => location.fragments));
-            changeIcon(buttonEl, true);
             fragments = locFragments.map(fragment => ({ ...fragment, feature: subtrackData }));
         } else {
             fragments = [];

--- a/src/section-templates/navigation.js
+++ b/src/section-templates/navigation.js
@@ -4,36 +4,10 @@ function PDBePvNavSection(ctx) {
     return html `<div class="protvistaRow">
 
         <!-- Top Menu Toolbar -->
-        <div class="protvistaCol1 protvistaToolbar" style="position:relative">
+        <div class="protvistaCol1 protvistaToolbar" style="position:relative; padding: 0">
             <span class="protvistaToolbarIcon" @click=${e => ctx.layoutHelper.resetView()} title="Reset view">
                 <i class="icon icon-common icon-history"></i>
             </span>
-
-            <!-- View / highlight menu -->
-            <span class="protvistaToolbarIcon" title="Highlight / View region" @click=${e => ctx.layoutHelper.openRangeMenu()}>
-                <i class="icon icon-common icon-star"></i>
-            </span>
-            <div class="rangeMenu viewMenuBox" style="display:none">
-                <div class="protvistaRangeMenuTitle">
-                    <div>Highlight / View region</div>
-                    <span class="icon icon-functional protvistaMenuClose" data-icon="x" title="Close" @click=${e => {e.stopPropagation();ctx.layoutHelper.openRangeMenu()}}></span>
-                </div>
-                <div class="protvistaForm rangeForm" style="width:170px;">
-                    <div style="float:left;width:48%;">
-                        From <br>
-                        <input type="number" class="pvRangeMenuStart" value="0" style="display:inline-block;margin:0;" min="1" max="${ctx.viewerData.length}" step="1" />
-                    </div>
-                    <div style="float:right;width:48%;">
-                        To <br>
-                        <input type="number" class="pvRangeMenuEnd" value="0" style="display:inline-block;margin:0;" min="1" max="${ctx.viewerData.length}" step="1" /> <br><br>
-                    </div>
-                    <div style="margin:0 0 10px 0;clear:both;">
-                        <input type="checkbox" class="pvRangeMenuHighlight" /> Highlight-only
-                    </div>                                
-                    <button class="button tiny" style="margin:0; letter-spacing: 1px;" @click=${e => ctx.layoutHelper.pvRangeMenuSubmit()}>Submit</button>
-                </div>
-            </div>
-            <!-- View / highlight menu -->
 
             <!-- Track categories settings menu -->
             <span class="protvistaToolbarIcon" title="Hide sections" @click=${e => ctx.layoutHelper.openCategorySettingsMenu()}>

--- a/src/section-templates/navigation.js
+++ b/src/section-templates/navigation.js
@@ -10,13 +10,13 @@ function PDBePvNavSection(ctx) {
             </span>
 
             <!-- Track categories settings menu -->
-            <span class="protvistaToolbarIcon" title="Hide sections" @click=${e => ctx.layoutHelper.openCategorySettingsMenu()}>
+            <span class="protvistaToolbarIcon" title="Hide sections" @click=${e => ctx.layoutHelper.toggleCategorySettingsMenu()}>
                 <i class="icon icon-common icon-eye-slash"></i>
             </span>
             <div class="settingsMenu viewMenuBox" style="display:none">
                 <div class="protvistaRangeMenuTitle">
                     <div>Hide sections</div>
-                    <span class="icon icon-functional protvistaMenuClose" data-icon="x" title="Close" @click=${e => {e.stopPropagation();ctx.layoutHelper.openCategorySettingsMenu()}}></span>
+                    <span class="icon icon-functional protvistaMenuClose" data-icon="x" title="Close" @click=${e => { e.stopPropagation(); ctx.layoutHelper.toggleCategorySettingsMenu() }}></span>
                 </div>
                 <div class="protvistaForm rangeForm" style="width:215px;max-height:400px;">
                     <table style="font-size:inherit;margin-bottom:0" class="pvHideOptionsTable">
@@ -35,8 +35,7 @@ function PDBePvNavSection(ctx) {
                         <tr style="display:none" class="variationOption"></tr>
                         </tbody>
                     </table>
-                    <br>
-                    <button class="button tiny" style="margin:0; letter-spacing: 1px;" @click=${e => ctx.layoutHelper.pvCategorySettingsMenuSubmit()}>Submit</button>
+                    <button class="button tiny" @click=${e => ctx.layoutHelper.pvCategorySettingsMenuSubmit()}>Submit</button>
                 </div>
             </div>
             <!-- Track categories settings menu -->

--- a/src/section-templates/sequence.js
+++ b/src/section-templates/sequence.js
@@ -30,7 +30,7 @@ function PDBePvSeqSection(ctx) {
         <!-- View menu -->
         
         <!-- Highlight menu -->
-        <span class="protvistaToolbarIcon" title="Highlight region" @click=${e => ctx.layoutHelper.openHighlightRangeMenu()}>
+        <span class="protvistaToolbarIcon highlightToolbarIcon" title="Highlight region" @click=${e => ctx.highlightActive ? ctx.setSubtrackFragmentsSelection({ isEnabled: false }) : ctx.layoutHelper.openHighlightRangeMenu() }>
             <i class="icon icon-common icon-star"></i>
         </span>
         <div class="highlightRangeMenu viewMenuBox" style="display:none">

--- a/src/section-templates/sequence.js
+++ b/src/section-templates/sequence.js
@@ -7,47 +7,51 @@ function PDBePvSeqSection(ctx) {
     <div class="protvistaCol1 protvistaToolbar" style="position:relative; align-items: flex-start; margin-bottom: 8px; padding: 0">
 
         <!-- View menu -->
-        <span class="protvistaToolbarIcon" title="View region" @click=${e => ctx.layoutHelper.openViewRangeMenu()}>
+        <span class="protvistaToolbarIcon" title="View region" @click=${e => ctx.layoutHelper.toggleViewRangeMenu()}>
             <i class="icon icon-common icon-search-plus"></i>
         </span>
         <div class="viewRangeMenu viewMenuBox" style="display:none">
             <div class="protvistaRangeMenuTitle">
                 <div>View region</div>
-                <span class="icon icon-functional protvistaMenuClose" data-icon="x" title="Close" @click=${e => { e.stopPropagation(); ctx.layoutHelper.openViewRangeMenu() }}></span>
+                <span class="icon icon-functional protvistaMenuClose" data-icon="x" title="Close" @click=${e => { e.stopPropagation(); ctx.layoutHelper.toggleViewRangeMenu() }}></span>
             </div>
             <div class="protvistaForm rangeForm" style="width:170px;">
-                <div style="float:left;width:48%;">
-                    From <br>
-                    <input type="number" class="pvViewRangeMenuStart" value="0" style="display:inline-block;margin:0;" min="1" max="${ctx.viewerData.length}" step="1" />
+                <div class="inputs">
+                    <div>
+                        From
+                        <input type="number" class="pvViewRangeMenuStart" value="0" min="1" max="${ctx.viewerData.length}" step="1" />
+                    </div>
+                    <div>
+                        To
+                        <input type="number" class="pvViewRangeMenuEnd" value="0" min="1" max="${ctx.viewerData.length}" step="1" />
+                    </div>
                 </div>
-                <div style="float:right;width:48%;">
-                    To <br>
-                    <input type="number" class="pvViewRangeMenuEnd" value="0" style="display:inline-block;margin:0;" min="1" max="${ctx.viewerData.length}" step="1" /> <br><br>
-                </div>                         
-                <button class="button tiny" style="margin:1em 0 0; letter-spacing: 1px;" @click=${e => ctx.layoutHelper.pvViewRangeMenuSubmit()}>Submit</button>
+                <button class="button tiny" @click=${e => ctx.layoutHelper.pvViewRangeMenuSubmit()}>Submit</button>
             </div>
         </div>
         <!-- View menu -->
         
         <!-- Highlight menu -->
-        <span class="protvistaToolbarIcon highlightToolbarIcon" title="Highlight region" @click=${e => ctx.highlightActive ? ctx.setSubtrackFragmentsSelection({ isEnabled: false }) : ctx.layoutHelper.openHighlightRangeMenu() }>
+        <span class="protvistaToolbarIcon highlightToolbarIcon" title="Highlight region" @click=${e => ctx.highlightActive ? ctx.setSubtrackFragmentsSelection({ isEnabled: false }) : ctx.layoutHelper.toggleHighlightRangeMenu() }>
             <i class="icon icon-common icon-star"></i>
         </span>
         <div class="highlightRangeMenu viewMenuBox" style="display:none">
             <div class="protvistaRangeMenuTitle">
                 <div>Highlight region</div>
-                <span class="icon icon-functional protvistaMenuClose" data-icon="x" title="Close" @click=${e => { e.stopPropagation(); ctx.layoutHelper.openHighlightRangeMenu() }}></span>
+                <span class="icon icon-functional protvistaMenuClose" data-icon="x" title="Close" @click=${e => { e.stopPropagation(); ctx.layoutHelper.toggleHighlightRangeMenu() }}></span>
             </div>
             <div class="protvistaForm rangeForm" style="width:170px;">
-                <div style="float:left;width:48%;">
-                    From <br>
-                    <input type="number" class="pvHighlightRangeMenuStart" value="0" style="display:inline-block;margin:0;" min="1" max="${ctx.viewerData.length}" step="1" />
+                <div class="inputs">
+                    <div>
+                        From
+                        <input type="number" class="pvHighlightRangeMenuStart" value="0" min="1" max="${ctx.viewerData.length}" step="1" />
+                    </div>
+                    <div>
+                        To
+                        <input type="number" class="pvHighlightRangeMenuEnd" value="0" min="1" max="${ctx.viewerData.length}" step="1" />
+                    </div>
                 </div>
-                <div style="float:right;width:48%;">
-                    To <br>
-                    <input type="number" class="pvHighlightRangeMenuEnd" value="0" style="display:inline-block;margin:0;" min="1" max="${ctx.viewerData.length}" step="1" /> <br><br>
-                </div>                              
-                <button class="button tiny" style="margin:1em 0 0; letter-spacing: 1px;" @click=${e => ctx.layoutHelper.pvHighlightRangeMenuSubmit()}>Submit</button>
+                <button class="button tiny" @click=${e => ctx.layoutHelper.pvHighlightRangeMenuSubmit()}>Submit</button>
             </div>
         </div>
         <!-- Highlight menu -->

--- a/src/section-templates/sequence.js
+++ b/src/section-templates/sequence.js
@@ -55,7 +55,7 @@ function PDBePvSeqSection(ctx) {
 
         <!-- Navigation Component -->
         <div class="protvistaCol2 pvSeqSection">
-            <protvista-sequence length="${ctx.viewerData.length}" sequence="${ctx.viewerData.sequence}"></protvista-sequence>
+            <protvista-pdb-sequence length="${ctx.viewerData.length}" sequence="${ctx.viewerData.sequence}"></protvista-pdb-sequence>
         </div>
 
     </div>`

--- a/src/section-templates/sequence.js
+++ b/src/section-templates/sequence.js
@@ -3,8 +3,55 @@ const { html } = require("lit-html")
 function PDBePvSeqSection(ctx) {
     return html `<div class="protvistaRow">
                     
-        <!-- Top Menu Toolbar -->
-        <div class="protvistaCol1">&nbsp;</div>
+    <!-- Top Menu Toolbar -->
+    <div class="protvistaCol1 protvistaToolbar" style="position:relative; align-items: flex-start; margin-bottom: 8px; padding: 0">
+
+        <!-- View menu -->
+        <span class="protvistaToolbarIcon" title="View region" @click=${e => ctx.layoutHelper.openViewRangeMenu()}>
+            <i class="icon icon-common icon-search-plus"></i>
+        </span>
+        <div class="viewRangeMenu viewMenuBox" style="display:none">
+            <div class="protvistaRangeMenuTitle">
+                <div>View region</div>
+                <span class="icon icon-functional protvistaMenuClose" data-icon="x" title="Close" @click=${e => { e.stopPropagation(); ctx.layoutHelper.openViewRangeMenu() }}></span>
+            </div>
+            <div class="protvistaForm rangeForm" style="width:170px;">
+                <div style="float:left;width:48%;">
+                    From <br>
+                    <input type="number" class="pvViewRangeMenuStart" value="0" style="display:inline-block;margin:0;" min="1" max="${ctx.viewerData.length}" step="1" />
+                </div>
+                <div style="float:right;width:48%;">
+                    To <br>
+                    <input type="number" class="pvViewRangeMenuEnd" value="0" style="display:inline-block;margin:0;" min="1" max="${ctx.viewerData.length}" step="1" /> <br><br>
+                </div>                         
+                <button class="button tiny" style="margin:1em 0 0; letter-spacing: 1px;" @click=${e => ctx.layoutHelper.pvViewRangeMenuSubmit()}>Submit</button>
+            </div>
+        </div>
+        <!-- View menu -->
+        
+        <!-- Highlight menu -->
+        <span class="protvistaToolbarIcon" title="Highlight region" @click=${e => ctx.layoutHelper.openHighlightRangeMenu()}>
+            <i class="icon icon-common icon-star"></i>
+        </span>
+        <div class="highlightRangeMenu viewMenuBox" style="display:none">
+            <div class="protvistaRangeMenuTitle">
+                <div>Highlight region</div>
+                <span class="icon icon-functional protvistaMenuClose" data-icon="x" title="Close" @click=${e => { e.stopPropagation(); ctx.layoutHelper.openHighlightRangeMenu() }}></span>
+            </div>
+            <div class="protvistaForm rangeForm" style="width:170px;">
+                <div style="float:left;width:48%;">
+                    From <br>
+                    <input type="number" class="pvHighlightRangeMenuStart" value="0" style="display:inline-block;margin:0;" min="1" max="${ctx.viewerData.length}" step="1" />
+                </div>
+                <div style="float:right;width:48%;">
+                    To <br>
+                    <input type="number" class="pvHighlightRangeMenuEnd" value="0" style="display:inline-block;margin:0;" min="1" max="${ctx.viewerData.length}" step="1" /> <br><br>
+                </div>                              
+                <button class="button tiny" style="margin:1em 0 0; letter-spacing: 1px;" @click=${e => ctx.layoutHelper.pvHighlightRangeMenuSubmit()}>Submit</button>
+            </div>
+        </div>
+        <!-- Highlight menu -->
+    </div>
 
         <!-- Navigation Component -->
         <div class="protvistaCol2 pvSeqSection">

--- a/src/section-templates/tracks.js
+++ b/src/section-templates/tracks.js
@@ -24,19 +24,19 @@ function PDBePvTracksSection(ctx) {
                         <button type="button" class="more-options" title="Show options" @click=${e => ctx.layoutHelper.openMoreOptions(trackIndex, subtrackIndex)}><i class="icon icon-common icon-ellipsis-h"></i></button>
                         <!--More options menu-->
                         <div class="moreOptionsMenu viewMenuBox moreOptionsMenu_${trackIndex}_${subtrackIndex}" style="display:none">
-                            <button type="button" class="more-options-action ${getHighlightClass(ctx, trackIndex, subtrackIndex)}" @click=${(ev) => highlightSubtrackFragments(ev, ctx, trackIndex, subtrackIndex, subtrackData)}>
+                            <button type="button" class="more-options-action ${getHighlightClass(ctx, trackIndex, subtrackIndex)}" @click=${(ev) => { highlightSubtrackFragments(ev, ctx, trackIndex, subtrackIndex, subtrackData); ctx.layoutHelper.hideMoreOptions(); }}>
                                 <span class="icon icon-common icon-star"></span>
                                 <span>Highlight fragments</span>
                             </button>
-                            <button type="button" class="more-options-action pvZoomIcon_${trackIndex}_${subtrackIndex}" @click=${e => { ctx.layoutHelper.zoomTrack({start:1, end: null, trackData: subtrackData}, trackIndex+'_'+subtrackIndex); }}>
+                            <button type="button" class="more-options-action pvZoomIcon_${trackIndex}_${subtrackIndex}" @click=${e => { ctx.layoutHelper.zoomTrack({ start: 1, end: null, trackData: subtrackData }, trackIndex + '_' + subtrackIndex); ctx.layoutHelper.hideMoreOptions(); }}>
                                 <span class="icon icon-common icon-search-plus"></span>
                                 <span>Zoom in</span>
                             </button>
-                            ${subtrackData.help ? html`<button type="button" class="more-options-action infoAction_${trackIndex}_${subtrackIndex}" @click=${e => ctx.layoutHelper.showInfoTooltip(trackIndex, subtrackIndex)}>
+                            ${subtrackData.help ? html`<button type="button" class="more-options-action infoAction_${trackIndex}_${subtrackIndex}" @click=${e => { ctx.layoutHelper.showInfoTooltip(trackIndex, subtrackIndex); ctx.layoutHelper.hideMoreOptions(); }}>
                                 <span class="icon icon-common icon-info"></span>
                                 More info
                             </button>` : ""}
-                            <button type="button" class="more-options-action" @click=${e => {e.stopPropagation();ctx.layoutHelper.hideSubTrack(trackIndex, subtrackIndex)}}>
+                            <button type="button" class="more-options-action" @click=${e => { e.stopPropagation(); ctx.layoutHelper.hideSubTrack(trackIndex, subtrackIndex); ctx.layoutHelper.hideMoreOptions(); ctx.layoutHelper.hideInfoTooltips(); }}>
                                 <span class="icon icon-common icon-eye-slash"></span>
                                 Hide
                             </button>

--- a/src/section-templates/tracks.js
+++ b/src/section-templates/tracks.js
@@ -21,22 +21,22 @@ function PDBePvTracksSection(ctx) {
                 <div class="protvistaRow pvSubtrackRow_${trackIndex}_${subtrackIndex}">
                     <div class="protvistaCol1 track-label" style=${styleMap(subtrackData.labelColor ? {backgroundColor: subtrackData.labelColor, borderBottom: '1px solid lightgrey'} : {})}>
                         <div class="pvSubtrackLabel_${trackIndex}_${subtrackIndex}" title="${subtrackData.label}"></div>
-                        <button type="button" class="more-options" title="Show options" @click=${e => ctx.layoutHelper.openMoreOptions(trackIndex, subtrackIndex)}><i class="icon icon-common icon-ellipsis-h"></i></button>
+                        <button type="button" class="more-options" title="Show options" @click=${e => ctx.layoutHelper.toggleMoreOptions(trackIndex, subtrackIndex)}><i class="icon icon-common icon-ellipsis-h"></i></button>
                         <!--More options menu-->
                         <div class="moreOptionsMenu viewMenuBox moreOptionsMenu_${trackIndex}_${subtrackIndex}" style="display:none">
-                            <button type="button" class="more-options-action ${getHighlightClass(ctx, trackIndex, subtrackIndex)}" @click=${(ev) => { highlightSubtrackFragments(ev, ctx, trackIndex, subtrackIndex, subtrackData); ctx.layoutHelper.hideMoreOptions(); }}>
+                            <button type="button" class="more-options-action ${getHighlightClass(ctx, trackIndex, subtrackIndex)}" @click=${(ev) => { highlightSubtrackFragments(ev, ctx, trackIndex, subtrackIndex, subtrackData); ctx.layoutHelper.hideTooltips(); }}>
                                 <span class="icon icon-common icon-star"></span>
                                 <span>Highlight fragments</span>
                             </button>
-                            <button type="button" class="more-options-action pvZoomIcon_${trackIndex}_${subtrackIndex}" @click=${e => { ctx.layoutHelper.zoomTrack({ start: 1, end: null, trackData: subtrackData }, trackIndex + '_' + subtrackIndex); ctx.layoutHelper.hideMoreOptions(); }}>
+                            <button type="button" class="more-options-action pvZoomIcon_${trackIndex}_${subtrackIndex}" @click=${e => { ctx.layoutHelper.zoomTrack({ start: 1, end: null, trackData: subtrackData }, trackIndex + '_' + subtrackIndex); ctx.layoutHelper.hideTooltips(); }}>
                                 <span class="icon icon-common icon-search-plus"></span>
                                 <span>Zoom in</span>
                             </button>
-                            ${subtrackData.help ? html`<button type="button" class="more-options-action infoAction_${trackIndex}_${subtrackIndex}" @click=${e => { ctx.layoutHelper.showInfoTooltip(trackIndex, subtrackIndex); ctx.layoutHelper.hideMoreOptions(); }}>
+                            ${subtrackData.help ? html`<button type="button" class="more-options-action infoAction_${trackIndex}_${subtrackIndex}" @click=${e => { ctx.layoutHelper.showInfoTooltip(trackIndex, subtrackIndex); }}>
                                 <span class="icon icon-common icon-info"></span>
                                 More info
                             </button>` : ""}
-                            <button type="button" class="more-options-action" @click=${e => { e.stopPropagation(); ctx.layoutHelper.hideSubTrack(trackIndex, subtrackIndex); ctx.layoutHelper.hideMoreOptions(); ctx.layoutHelper.hideInfoTooltips(); }}>
+                            <button type="button" class="more-options-action" @click=${e => { e.stopPropagation(); ctx.layoutHelper.hideSubTrack(trackIndex, subtrackIndex); ctx.layoutHelper.hideTooltips(); }}>
                                 <span class="icon icon-common icon-eye-slash"></span>
                                 Hide
                             </button>
@@ -44,7 +44,7 @@ function PDBePvTracksSection(ctx) {
                         <!--More options menu end-->
                         <!--Info tooltip-->
                             <div class="infoTooltip viewMenuBox infoTooltip_${trackIndex}_${subtrackIndex}">
-                                <div class="info-header"><span class="title">${subtrackData.label}</span><span class="icon icon-common icon-close" title="Close" @click=${e => ctx.layoutHelper.hideInfoTooltips()}></span></div>
+                                <div class="info-header"><span class="title">${subtrackData.label}</span><span class="icon icon-common icon-close" title="Close" @click=${e => ctx.layoutHelper.hideTooltips()}></span></div>
                                 ${subtrackData.help}
                             </div>
                         <!--Info tooltip end-->

--- a/styles/protvista-pdb.css
+++ b/styles/protvista-pdb.css
@@ -430,6 +430,7 @@ protvista-tooltip {
     -webkit-box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
     -moz-box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
     box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.2);
+    background-color: #fff;
     /*opacity: .9;*/
 }
 
@@ -458,6 +459,9 @@ protvista-tooltip .tooltip-body {
 protvista-tooltip .tooltip-header {
     background-color: #595959;
     line-height: 3em;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
 }
 
 /* protvista-tooltip .tooltip-header::before {

--- a/styles/protvista-pdb.css
+++ b/styles/protvista-pdb.css
@@ -329,7 +329,7 @@
     border: 1px solid #828181;
     background-color: #828181;
     border-radius: 50%;
-    margin-right: 10px;
+    margin-right: 6px;
     cursor: pointer;
     align-items: center;
     justify-content: center;

--- a/styles/protvista-pdb.css
+++ b/styles/protvista-pdb.css
@@ -740,3 +740,7 @@ opacity: 0.4;
 #filter-uncertain .protvista_checkbox_input:checked + .protvista_checkbox_label::before {
 opacity: 1;
 }
+
+.feature {
+    cursor: pointer;
+}

--- a/styles/protvista-pdb.css
+++ b/styles/protvista-pdb.css
@@ -360,7 +360,7 @@
 .protvistaMenuClose{
     position: absolute;
     right: 10px;
-    top: 14px;
+    top: 10px;
     color: #6d6d6d;
     font-size: 12px;
     cursor: pointer;

--- a/styles/protvista-pdb.css
+++ b/styles/protvista-pdb.css
@@ -744,3 +744,14 @@ opacity: 1;
 .feature {
     cursor: pointer;
 }
+
+.rangeForm .inputs {
+    display: flex;
+    justify-content: space-evenly;
+}
+
+.rangeForm .button {
+    display: block;
+    margin: 1.5em 0 0;
+    letter-spacing: 1px;
+}


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/865czey7a

### :memo: Implementation

The main issue was happening when different blocks had different zooms on tracks. For that reason, when hovering over the Molstar sequence, sometimes the thin highlight wasn't being shown on tracks. Later when hovering on some track annotation, that thin highlight was only removed from that block and not the other ones (protvista-pdb instances).

Some key features/fixes:
- Highlight Molstar selection even with zoom is out of range (added highlight on NavigationBar)
- Highlight Molstar selection and track annotations on NavigationBar to occur in all blocks
- Click on track annotation to make highlight stay, and highlight on NavigationBar in all blocks
- Protvista menu action "Highlight fragments": to also show on NavigationBar on all blocks
- Undo highlight action on tracks to be present on all blocks when some highlight occurs
- Molstar highlight when clicking on some track annotation
- Added highlights also on ProtvistaSequence
- Main "highlight" action, to update to "Undo highlight" when highlight occurs
- Main "Reset" action, removes all highlights (also on Molstar)
- Highlight color on molstar is now the color of the track annotation
- Main "highlight" action to behave as the "click" highlight
- Main "highlight" action to focus and highlight on molstar (color would be the generic / default)

Minor fixes:
- Make icons don't shrink when the right panel is smaller (separate "View / Highlight" menu actions)
   - Both actions were being done separately. When the checkbox was checked, only the highlight occurred. When the checkbox wasn't checked, it was only applying the zoom. Both actions have been separated.
- Added highlight on NavigationBar for Carbohydrates (spheres and cubes) that are offsite the range of the sequence
- Hide the "More options" tooltip when the button is clicked again
- Highlight small annotations as on the "Validation - Quality" block, to have a minimum visible width 
- On "More options" menu tooltip: remove the tooltip after action is triggered
- Track annotation tooltip seems cropped or hidden when is too close to the right side of the screen
- ProtvistaSequence handles were behind highlights
- Protvista D3 errors on negative and/or missing values

### :art: Screenshots

![image](https://github.com/EyeSeeTea/protvista-pdb/assets/43061485/944c08cf-7051-45c2-a6ee-a480177230d7)
_Molstar selection_

![image](https://github.com/EyeSeeTea/protvista-pdb/assets/43061485/43322a82-32d4-4fd2-a76f-e696a0e3f8b0)
_Hover highlight on yellow, click on orange_

![image](https://github.com/EyeSeeTea/protvista-pdb/assets/43061485/054463e2-b9e8-4ab7-bdd8-947b11952562)
_Undo highlight on all blocks_

![image](https://github.com/EyeSeeTea/protvista-pdb/assets/43061485/2655c01b-5dea-4470-a2bf-fdfff9f9a7a7)
_Molstar selection on "Highlight fragments" or click on track annotation_

